### PR TITLE
Remove video unix group check for GPU plugin

### DIFF
--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -50,7 +50,6 @@ check_user_access() {
 }
 
 check_user_access GPU /dev/dri/render render
-check_user_access GPU /dev/dri/card video # TODO: verify this requirement
 check_user_access NPU /dev/accel/accel render
 
 exec "${cmd[@]}"


### PR DESCRIPTION
OpenVINO team confirmed a user only needs to be in the `render` group to fully use the GPU plugin: https://github.com/openvinotoolkit/openvino/issues/27762#issuecomment-2538029330