### PR TITLE
Build for arm64 and bump upstream version

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,20 @@ plugs:
     content: openvino-libs-2404
     target: $SNAP/openvino
 
-environment:
-  LD_LIBRARY_PATH: $SNAP/openvino:$LD_LIBRARY_PATH
-
 apps:
   openvino-enabled-app:
+    command-chain: ["command-chain/openvino-launch"]
     command: ...
     plugs:
       - openvino-libs
+
+parts:
+  ...
+  command-chain-openvino:
+    plugin: dump
+    source-type: git
+    source: https://github.com/canonical/openvino-toolkit-snap.git
+    source-tag: 2024.5.0-0
+    stage:
+      - command-chain/openvino-launch
 ```

--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -44,6 +44,7 @@ check_user_access() {
     if ! test -r "${node}" || ! test -w "${node}"; then
       echo "Warning: to use device ${node} with the ${device_type} plugin, the user must have read and write access to ${node}."
       echo "Please run 'sudo chown root:${required_group} ${node} && sudo chmod g+rw ${node}'."
+      echo "Also confirm (run 'snap connections') that snap interfaces required to access ${node} are connected."
       return 0
     fi
   done

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -9,6 +9,8 @@ confinement: strict
 adopt-info: openvino
 
 platforms:
+  arm64:
+    build-on: [amd64]
   amd64:
 
 # the recommended mountpoint for the content is /openvino
@@ -23,7 +25,7 @@ parts:
   openvino:
     source-type: git
     source: https://github.com/openvinotoolkit/openvino.git
-    source-tag: 2024.5.0
+    source-tag: 2024.6.0
     plugin: cmake
     cmake-parameters:
       - -DENABLE_PYTHON=ON
@@ -32,7 +34,7 @@ parts:
     override-pull: |
       craftctl default
       git submodule update --init --recursive
-      craftctl set version="$(git describe --tags --abbrev=4 --always)"
+      craftctl set version="$(git describe --tags)"
     build-packages:
       - ca-certificates
       - file


### PR DESCRIPTION
[According to OpenVINO documentation](https://docs.openvino.ai/2024/about-openvino/release-notes-openvino/system-requirements.html), OpenVINO supports ARM64 so this PR enables building of the snap for that architecture. 

See [this section from snapcraft docs](https://snapcraft.io/docs/architectures#how-to-build-a-snap-for-a-different-architecture) on the yaml syntax required, but essentially the `platforms` section is now requesting two builds of the snap (amd64 and arm64) where both will be built on an amd64 host (which is nice because we don't have to use `remote-build` to use the Launchpad farm).

I have tested the new build (from an amd64 machine) and two versions of the snap were created for each architecture.

I also made a few other minor updates while I was at it:

* Bump to latest upstream version
* Improve warning message to address https://github.com/canonical/openvino-toolkit-snap/issues/5
* Improve README for snap developers wanting to use this content producer snap