### PR TITLE
Integrate testing with testflinger and checkbox

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -64,16 +64,23 @@ test_data:
       sudo snap install --dangerous --classic ./checkbox-openvino-toolkit-2404_*_amd64.snap
     '
 
-    # Enable non-root access to the NPU device node
+    # Install test dependencies
+    ssh ubuntu@$DEVICE_IP '
+      checkbox-openvino-toolkit-2404.install-full-deps
+    '
+
+    echo "[INFO] Sleeping for 60 seconds to allow NPU firmware to load."
+    sleep 60
+
+    # Enable non-root access to the NPU device node.
+    # Note, this must be run after the intel-npu-driver snap
+    # is installed in `install-full-deps` as the intel_vpu
+    # kernel module is re-loaded which resets permissions on the
+    # NPU device node.
     ssh ubuntu@$DEVICE_IP '
       sudo usermod -a -G render $USER
       sudo chown root:render /dev/accel/accel*
       sudo chmod g+rw /dev/accel/accel*
-    '
-
-    # Install test dependencies
-    ssh ubuntu@$DEVICE_IP '
-      checkbox-openvino-toolkit-2404.install-full-deps
     '
 
     # Run tests

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -1,0 +1,85 @@
+job_queue: REPLACE_QUEUE
+output_timeout: 7200
+provision_data:
+  REPLACE_PROVISION_DATA
+test_data:
+  test_cmds: |
+
+    # Exit immediately if a test fails
+    set -e
+
+    # Clone repo from appropriate branch/commit.
+    ssh ubuntu@$DEVICE_IP '
+      sudo DEBIAN_FRONTEND=noninteractive apt update
+      sudo DEBIAN_FRONTEND=noninteractive apt -y upgrade
+      sudo DEBIAN_FRONTEND=noninteractive apt -y install git curl
+      git clone -b REPLACE_BRANCH \
+        https://github.com/canonical/openvino-toolkit-snap.git \
+        ~ubuntu/openvino-toolkit-snap
+      cd ~ubuntu/openvino-toolkit-snap
+      echo "Current git branch: $(git branch --show-current)"
+      echo "Latest commit:"
+      git log --name-status HEAD^..HEAD
+    '
+
+    # Install dependencies
+    ssh ubuntu@$DEVICE_IP '
+      sudo snap install --classic snapcraft
+      sudo snap install lxd --channel=5.21/stable
+      sudo adduser ubuntu lxd
+      sudo snap refresh
+      sudo snap install --beta intel-npu-driver
+    '
+
+    # Disable swap and IPv6
+    ssh ubuntu@$DEVICE_IP '
+      sudo sysctl -w vm.swappiness=0
+      sudo echo "vm.swappiness = 0" | sudo tee -a /etc/sysctl.conf
+      sudo swapoff -a
+      echo "net.ipv6.conf.all.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+      echo "net.ipv6.conf.default.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+      echo "net.ipv6.conf.lo.disable_ipv6=1" | sudo tee -a /etc/sysctl.conf
+      sudo sysctl -p
+    '
+
+    # Build and install openvino-toolkit-2404 snap
+    ssh ubuntu@$DEVICE_IP '
+      lxd init --auto
+      cd ~ubuntu/openvino-toolkit-snap
+      snapcraft --build-for=amd64
+      sudo snap install --dangerous ./openvino-toolkit-2404_*_amd64.snap
+    '
+
+    # Build and install sample-consumer snap
+    ssh ubuntu@$DEVICE_IP '
+      cd ~ubuntu/openvino-toolkit-snap/sample-consumer
+      snapcraft
+      sudo snap install --dangerous ./openvino-sample-consumer_1.0.0_amd64.snap
+      sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs
+      sudo snap connect openvino-sample-consumer:openvino-libs openvino-toolkit-2404:openvino-libs
+    '
+
+    # Build and install checkbox-openvino-toolkit-2404 snap
+    ssh ubuntu@$DEVICE_IP '
+      cd ~ubuntu/openvino-toolkit-snap/checkbox
+      sudo snap install checkbox22
+      snapcraft
+      sudo snap install --dangerous --classic ./checkbox-openvino-toolkit-2404_*_amd64.snap
+    '
+
+    # Enable non-root access to the NPU device node
+    ssh ubuntu@$DEVICE_IP '
+      sudo usermod -a -G render $USER
+      sudo chown root:render /dev/accel/accel0
+      sudo chmod g+rw /dev/accel/accel0
+    '
+
+    # Install test dependencies
+    ssh ubuntu@$DEVICE_IP '
+      checkbox-openvino-toolkit-2404.install-full-deps
+    '
+
+    # Run tests
+    ssh ubuntu@$DEVICE_IP '
+      checkbox-openvino-toolkit-2404.test-runner-automated
+    '

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -28,7 +28,6 @@ test_data:
       sudo snap install lxd --channel=5.21/stable
       sudo adduser ubuntu lxd
       sudo snap refresh
-      sudo snap install --beta intel-npu-driver
     '
 
     # Disable swap and IPv6
@@ -55,8 +54,6 @@ test_data:
       cd ~ubuntu/openvino-toolkit-snap/sample-consumer
       snapcraft
       sudo snap install --dangerous ./openvino-sample-consumer_1.0.0_amd64.snap
-      sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs
-      sudo snap connect openvino-sample-consumer:openvino-libs openvino-toolkit-2404:openvino-libs
     '
 
     # Build and install checkbox-openvino-toolkit-2404 snap

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -67,8 +67,8 @@ test_data:
     # Enable non-root access to the NPU device node
     ssh ubuntu@$DEVICE_IP '
       sudo usermod -a -G render $USER
-      sudo chown root:render /dev/accel/accel0
-      sudo chmod g+rw /dev/accel/accel0
+      sudo chown root:render /dev/accel/accel*
+      sudo chmod g+rw /dev/accel/accel*
     '
 
     # Install test dependencies

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,0 +1,56 @@
+name: Build snap and run integration tests on testflinger device
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'snap/**'
+      - 'command-chain/**'
+      - 'checkbox/bin/**'
+      - 'checkbox/checkbox-provider-openvino-toolkit-2404/**'
+      - 'checkbox/snap/**'
+      - 'sample-consumer/src/**'
+      - 'sample-consumer/snap/**'
+      - '.github/workflows/integration-tests.yaml'
+      - '.github/testflinger/job-def.yaml'
+    branches:
+      - main
+      - frenchwr/integrate-testing # temporary for testing
+  pull_request:
+    paths:
+      - 'snap/**'
+      - 'command-chain/**'
+      - 'checkbox/bin/**'
+      - 'checkbox/checkbox-provider-openvino-toolkit-2404/**'
+      - 'checkbox/snap/**'
+      - 'sample-consumer/src/**'
+      - 'sample-consumer/snap/**'
+      - '.github/workflows/integration-tests.yaml'
+      - '.github/testflinger/job-def.yaml'
+    branches:
+      - main
+
+env:
+  BRANCH: ${{ github.head_ref || github.ref_name }}
+
+jobs:
+  openvino-toolkit-2404-validation:
+    name: OpenVINO Toolkit 2404 Validation
+    runs-on: [testflinger]
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+      - name: Build job file from template with oemscript provisioning
+        env:
+          QUEUE: "dell-xps-13-9340-c32267"
+          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso"
+        run: |
+          sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
+          -e "s|REPLACE_QUEUE|${QUEUE}|" \
+          -e "s|REPLACE_PROVISION_DATA|${PROVISION_DATA}|" \
+          ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
+          ${GITHUB_WORKSPACE}/job.yaml
+      - name: Submit testflinger job
+        uses: canonical/testflinger/.github/actions/submit@main
+        with:
+          poll: true
+          job-path: ${GITHUB_WORKSPACE}/job.yaml

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -13,8 +13,7 @@ on:
       - '.github/workflows/integration-tests.yaml'
       - '.github/testflinger/job-def.yaml'
     branches:
-      - main
-      - frenchwr/integrate-testing # temporary for testing
+      - openvino-toolkit-2404
   pull_request:
     paths:
       - 'snap/**'
@@ -27,7 +26,7 @@ on:
       - '.github/workflows/integration-tests.yaml'
       - '.github/testflinger/job-def.yaml'
     branches:
-      - main
+      - openvino-toolkit-2404
 
 env:
   BRANCH: ${{ github.head_ref || github.ref_name }}

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -1,0 +1,52 @@
+name: Build snap and run smoke tests
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - 'snap/**'
+      - 'command-chain/**'
+      - '.github/workflows/smoke-tests.yaml'
+    branches:
+      - main
+      - frenchwr/integrate-testing # temporary for testing
+  pull_request:
+    paths:
+      - 'snap/**'
+      - 'command-chain/**'
+      - '.github/workflows/smoke-tests.yaml'
+    branches:
+      - main
+
+env:
+  SNAP_ARTIFACT_NAME: openvino-toolkit-2404-snap
+  SNAP_FILE: openvino-toolkit-2404.snap
+
+jobs:
+  snap-build:
+    name: Build snap
+    runs-on: [self-hosted, linux, X64, large, noble]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: snapcore/action-build@v1
+        id: snapcraft
+        with:
+          snapcraft-args: "--build-for=amd64 -o ${{ env.SNAP_FILE }}"
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ${{ env.SNAP_ARTIFACT_NAME }}
+          path: ${{ steps.snapcraft.outputs.snap }}
+
+  snap-test:
+    name: Install and verify snap
+    runs-on: ubuntu-24.04
+    needs:
+      - snap-build
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: ${{ env.SNAP_ARTIFACT_NAME }}
+      - name: Install snap
+        shell: bash
+        run: |
+          sudo snap install --dangerous ${{ env.SNAP_FILE }}
+          snap list

--- a/.github/workflows/smoke-tests.yaml
+++ b/.github/workflows/smoke-tests.yaml
@@ -7,15 +7,14 @@ on:
       - 'command-chain/**'
       - '.github/workflows/smoke-tests.yaml'
     branches:
-      - main
-      - frenchwr/integrate-testing # temporary for testing
+      - openvino-toolkit-2404
   pull_request:
     paths:
       - 'snap/**'
       - 'command-chain/**'
       - '.github/workflows/smoke-tests.yaml'
     branches:
-      - main
+      - openvino-toolkit-2404
 
 env:
   SNAP_ARTIFACT_NAME: openvino-toolkit-2404-snap

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -4,10 +4,19 @@ This directory contains the Checkbox OpenVINO Toolkit 2404 Provider, including t
 
 ## Installation
 
+Prerequisites:
+
 ```
 sudo snap install --classic snapcraft
 sudo snap install checkbox22
+sudo snap install lxd
+sudo adduser ubuntu lxd
 lxd init --auto
+```
+
+Now build and install the sample content consumer snap and the checkbox provider for OpenVINO Toolkit 2404:
+
+```
 git clone -b openvino-toolkit-2404 https://github.com/canonical/openvino-toolkit-snap.git
 
 # first build and install content consumer snap and install it

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -1,0 +1,50 @@
+# Checkbox Provider for OpenVINO Toolkit 2404 Snap
+
+This directory contains the Checkbox OpenVINO Toolkit 2404 Provider, including the snap recipe for building the snap and integrating with the Checkbox snap. The test plan integrates with the OpenVINO Python API.
+
+## Installation
+
+```
+sudo snap install --classic snapcraft
+sudo snap install checkbox22
+lxd init --auto
+git clone -b openvino-toolkit-2404 https://github.com/canonical/openvino-toolkit-snap.git
+
+# first build and install content consumer snap and connect its snapd interfaces
+cd openvino-toolkit-snap/sample-consumer
+snapcraft
+sudo snap install --dangerous ./openvino-sample-consumer_1.0.0_amd64.snap
+sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs
+sudo snap connect openvino-sample-consumer:openvino-libs openvino-toolkit-2404:openvino-libs
+
+# now build and install the checkbox tests for openvino-toolkit-2404
+cd ../openvino-toolkit-snap/checkbox
+snapcraft
+sudo snap install --dangerous --classic ./checkbox-openvino-toolkit-2404_1.0.0_amd64.snap
+```
+
+## Installing test dependencies
+
+```
+checkbox-openvino-toolkit-2404.install-full-deps
+```
+
+Among the dependencies are support for Intel GPUs and NPUs.
+
+Note this will NOT install the `openvino-toolkit-2404` snap by default. This is by design as typically tests will be run on a modified version of the snap built and installed locally. To install the latest version from the `latest/beta` channel in the Snap Store use:
+
+```
+checkbox-openvino-toolkit-2404.install-full-deps --install_from_store
+```
+
+## Automated run
+
+```
+checkbox-openvino-toolkit-2404.test-runner-automated
+```
+
+## Manual run
+
+```
+checkbox-openvino-toolkit-2404.test-runner
+```

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -10,12 +10,10 @@ sudo snap install checkbox22
 lxd init --auto
 git clone -b openvino-toolkit-2404 https://github.com/canonical/openvino-toolkit-snap.git
 
-# first build and install content consumer snap and connect its snapd interfaces
+# first build and install content consumer snap and install it
 cd openvino-toolkit-snap/sample-consumer
 snapcraft
 sudo snap install --dangerous ./openvino-sample-consumer_1.0.0_amd64.snap
-sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs
-sudo snap connect openvino-sample-consumer:openvino-libs openvino-toolkit-2404:openvino-libs
 
 # now build and install the checkbox tests for openvino-toolkit-2404
 cd ../openvino-toolkit-snap/checkbox
@@ -29,7 +27,7 @@ sudo snap install --dangerous --classic ./checkbox-openvino-toolkit-2404_1.0.0_a
 checkbox-openvino-toolkit-2404.install-full-deps
 ```
 
-Among the dependencies that are installed is the `openvino-ai-plugins-gimp` snap from the store, which will auto-plug into snapd slots provided by the `openvino-toolkit-2404` snap for testing.
+Among the dependencies that are installed is the `openvino-ai-plugins-gimp` snap from the store. Snapd interfaces are also manually connected where required.
 
 By default, `checkbox-openvino-toolkit-2404.install-full-deps` will NOT install the `openvino-toolkit-2404` snap. This is by design as typically tests will be run on a modified version of the snap built and installed locally. To install the latest version from the `latest/beta` channel in the Snap Store use:
 

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -37,6 +37,14 @@ Note this will NOT install the `openvino-toolkit-2404` snap by default. This is 
 checkbox-openvino-toolkit-2404.install-full-deps --install_from_store
 ```
 
+Note that the checkbox tests will install models to the same path(s) used by the `openvino-ai-plugins-gimp.model-setup` application. This is because the application has permissions to only write to certain paths, and thus users are not allowed the flexibility to install to any arbitrary path. Therefore, in order for the GIMP plugin tests to run, the models and a config file should be absent in order to test whether the application creates these files in the expected locations. Between checkbox runs, you can remove these files and directories by passing the `--clean_plugin_dirs` option:
+
+```
+checkbox-openvino-toolkit-2404.install-full-deps --clean_plugin_dirs
+```
+
+Please use this with caution as it will remove models that you may have previously installed to a machine for running the OpenVINO AI plugins with GIMP.
+
 ## Automated run
 
 ```

--- a/checkbox/README.md
+++ b/checkbox/README.md
@@ -29,9 +29,9 @@ sudo snap install --dangerous --classic ./checkbox-openvino-toolkit-2404_1.0.0_a
 checkbox-openvino-toolkit-2404.install-full-deps
 ```
 
-Among the dependencies are support for Intel GPUs and NPUs.
+Among the dependencies that are installed is the `openvino-ai-plugins-gimp` snap from the store, which will auto-plug into snapd slots provided by the `openvino-toolkit-2404` snap for testing.
 
-Note this will NOT install the `openvino-toolkit-2404` snap by default. This is by design as typically tests will be run on a modified version of the snap built and installed locally. To install the latest version from the `latest/beta` channel in the Snap Store use:
+By default, `checkbox-openvino-toolkit-2404.install-full-deps` will NOT install the `openvino-toolkit-2404` snap. This is by design as typically tests will be run on a modified version of the snap built and installed locally. To install the latest version from the `latest/beta` channel in the Snap Store use:
 
 ```
 checkbox-openvino-toolkit-2404.install-full-deps --install_from_store
@@ -43,7 +43,7 @@ Note that the checkbox tests will install models to the same path(s) used by the
 checkbox-openvino-toolkit-2404.install-full-deps --clean_plugin_dirs
 ```
 
-Please use this with caution as it will remove models that you may have previously installed to a machine for running the OpenVINO AI plugins with GIMP.
+**IMPORTANT**: please use this with caution as it will remove models that you may have previously installed to a machine for running the OpenVINO AI plugins with GIMP.
 
 ## Automated run
 

--- a/checkbox/bin/checkbox-cli-wrapper
+++ b/checkbox/bin/checkbox-cli-wrapper
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# wrapper around the checkbox-cli
+exec /snap/checkbox22/current/bin/checkbox-cli "$@"

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+optional_arg=$1
+if [ "${optional_arg}" = "--install_from_store" ]; then
+  echo "Installing openvino-toolkit-2404 from the beta channel in the Snap Store."
+  sudo snap install --beta openvino-toolkit-2404
+fi
+
+if ! snap list openvino-toolkit-2404 2>&1 >/dev/null
+then
+  echo "Error: openvino-toolkit-2404 snap is not installed!"
+  echo "Either install the openvino-toolkit-2404 snap locally or from the store (using --install_from_store)"
+  exit 1
+fi
+
+if ! snap list openvino-sample-consumer 2>&1 >/dev/null
+then
+  echo "Error: openvino-sample-consumer snap is not installed!"
+  echo "Please build and install it locally."
+  exit 1
+fi
+
+if ! snap connections openvino-sample-consumer | grep -wq npu-libs-2404
+then
+  echo "Error: the npu-libs plug for openvino-sample-consumer is not connected."
+  echo "Please run 'sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs'"
+  exit 1
+fi
+
+if ! snap connections openvino-sample-consumer | grep -wq openvino-libs-2404
+then
+  echo "Error: the openvino-libs plug for openvino-sample-consumer is not connected."
+  echo "Please run 'sudo snap connect openvino-sample-consumer:openvino-libs openvino-toolkit-2404:openvino-libs'"
+  exit 1
+fi
+
+if ! snap connections openvino-sample-consumer | grep -wq custom-device
+then
+  echo "Error: the intel-npu plug for openvino-sample-consumer is not connected."
+  echo "Please run 'sudo snap connect openvino-sample-consumer:intel-npu intel-npu-driver:intel-npu'"
+  exit 1
+fi
+
+if ! snap connections openvino-sample-consumer | grep -wq opengl
+then
+  echo "Error: the opengl plug for openvino-sample-consumer is not connected."
+  echo "Please run 'sudo snap connect openvino-sample-consumer:opengl'"
+  exit 1
+fi
+
+sudo DEBIAN_FRONTEND=noninteractive apt install -y intel-gpu-tools

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -1,7 +1,8 @@
 #!/bin/bash
 
-optional_arg=$1
-if [ "${optional_arg}" = "--install_from_store" ]; then
+optional_arg_A=$1
+optional_arg_B=$2
+if [ "${optional_arg_A}" = "--install_from_store" ] || [ "${optional_arg_B}" = "--install_from_store" ]; then
   echo "Installing openvino-toolkit-2404 from the beta channel in the Snap Store."
   sudo snap install --beta openvino-toolkit-2404
 fi
@@ -48,4 +49,13 @@ then
   exit 1
 fi
 
-sudo DEBIAN_FRONTEND=noninteractive apt install -y intel-gpu-tools
+sudo DEBIAN_FRONTEND=noninteractive apt install -y intel-gpu-tools jq
+sudo snap install openvino-ai-plugins-gimp --beta
+
+if [ "${optional_arg_A}" = "--clean_plugin_dirs" ] || [ "${optional_arg_B}" = "--clean_plugin_dirs" ]; then
+  CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
+  MODEL_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp
+  echo "Removing ${CONFIG_FILE} and ${MODEL_DIR} for the next checkbox run."
+  rm -f ${CONFIG_FILE}
+  rm -rf ${MODEL_DIR}
+fi

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -21,36 +21,19 @@ then
   exit 1
 fi
 
-if ! snap connections openvino-sample-consumer | grep -wq npu-libs-2404
-then
-  echo "Error: the npu-libs plug for openvino-sample-consumer is not connected."
-  echo "Please run 'sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs'"
-  exit 1
-fi
-
-if ! snap connections openvino-sample-consumer | grep -wq openvino-libs-2404
-then
-  echo "Error: the openvino-libs plug for openvino-sample-consumer is not connected."
-  echo "Please run 'sudo snap connect openvino-sample-consumer:openvino-libs openvino-toolkit-2404:openvino-libs'"
-  exit 1
-fi
-
-if ! snap connections openvino-sample-consumer | grep -wq custom-device
-then
-  echo "Error: the intel-npu plug for openvino-sample-consumer is not connected."
-  echo "Please run 'sudo snap connect openvino-sample-consumer:intel-npu intel-npu-driver:intel-npu'"
-  exit 1
-fi
-
-if ! snap connections openvino-sample-consumer | grep -wq opengl
-then
-  echo "Error: the opengl plug for openvino-sample-consumer is not connected."
-  echo "Please run 'sudo snap connect openvino-sample-consumer:opengl'"
-  exit 1
-fi
-
 sudo DEBIAN_FRONTEND=noninteractive apt install -y intel-gpu-tools jq
+sudo snap install intel-npu-driver --beta
 sudo snap install openvino-ai-plugins-gimp --beta
+
+# the content interfaces require manual connection
+sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs
+sudo snap connect openvino-sample-consumer:openvino-libs openvino-toolkit-2404:openvino-libs
+
+# Since openvino-toolkit-2404 snap could be built and installed locally, this
+# means that some of the interfaces may not autoconnect.
+sudo snap connect openvino-ai-plugins-gimp:npu-libs intel-npu-driver:npu-libs
+sudo snap connect openvino-ai-plugins-gimp:openvino-libs openvino-toolkit-2404:openvino-libs
+sudo snap connect openvino-ai-plugins-gimp:dot-local-share-openvino-ai-plugins-gimp
 
 if [ "${optional_arg_A}" = "--clean_plugin_dirs" ] || [ "${optional_arg_B}" = "--clean_plugin_dirs" ]; then
   CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json

--- a/checkbox/bin/shell-wrapper
+++ b/checkbox/bin/shell-wrapper
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "$SNAP_NAME runtime shell, type 'exit' to quit the session"
+exec bash

--- a/checkbox/bin/test-runner
+++ b/checkbox/bin/test-runner
@@ -1,0 +1,8 @@
+#!/usr/bin/env -S checkbox-cli-wrapper
+[launcher]
+app_id = com.canonical.certification:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.certification::openvino-python

--- a/checkbox/bin/test-runner-automated
+++ b/checkbox/bin/test-runner-automated
@@ -1,0 +1,17 @@
+#!/usr/bin/env -S checkbox-cli-wrapper
+[launcher]
+app_id = com.canonical.certification:checkbox
+launcher_version = 1
+stock_reports = text, submission_files
+
+[test plan]
+unit = com.canonical.certification::openvino-python
+forced = yes
+
+[test selection]
+forced = yes
+
+[ui]
+type = silent
+auto_retry = no
+

--- a/checkbox/bin/wrapper_local
+++ b/checkbox/bin/wrapper_local
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+case "$SNAP_ARCH" in
+    "amd64") ARCH='x86_64-linux-gnu'
+    ;;
+    "i386") ARCH='i386-linux-gnu'
+    ;;
+    "arm64") ARCH='aarch64-linux-gnu'
+    ;;
+    "armhf") ARCH='arm-linux-gnueabihf'
+    ;;
+    *)
+        echo "Unsupported architecture: $SNAP_ARCH"
+    ;;
+esac
+
+################################################
+# Launcher common exports for any checkbox app #
+################################################
+
+RUNTIME=/snap/checkbox22/current
+if [ ! -d "$RUNTIME" ]; then
+    echo "You need to install the checkbox22 snap."
+    echo ""
+    echo "You can do this with this command:"
+    echo "snap install checkbox22"
+    exit 1
+fi
+
+export LC_ALL=C.UTF-8
+PERL_VERSION=$(perl -e '$^V=~/^v(\d+\.\d+)/;print $1')
+export PERL5LIB="$PERL5LIB:$SNAP/usr/lib/$ARCH/perl/$PERL_VERSION:$SNAP/usr/lib/$ARCH/perl5/$PERL_VERSION:$SNAP/usr/share/perl/$PERL_VERSION:$SNAP/usr/share/perl5"
+export GI_TYPELIB_PATH=$SNAP/usr/lib/girepository-1.0:$SNAP/usr/lib/$ARCH/girepository-1.0
+export PATH="$SNAP/usr/sbin:$SNAP/sbin:$SNAP/usr/bin:$SNAP/bin:/snap/bin:$PATH"
+export ALSA_CONFIG_PATH=$SNAP/usr/share/alsa/alsa.conf:$SNAP/usr/share/alsa/pcm/default.conf
+export PYTHONPATH="$SNAP/lib:$SNAP/usr/lib/python3/dist-packages:$PYTHONPATH"
+export PATH="$SNAP/providers/checkbox-provider-openvino-toolkit-2404/bin/:$PATH"
+
+if [ -e $RUNTIME/wrapper_common_classic ]; then
+  . $RUNTIME/wrapper_common_classic
+else
+  echo "ERROR: no $RUNTIME/wrapper_common_classic found"
+  exit 0
+fi
+
+exec "$@"

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/manage.py
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/manage.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+from plainbox.provider_manager import setup, N_
+
+# You can inject other stuff here but please don't go overboard.
+#
+# In particular, if you need comprehensive compilation support to get
+# your bin/ populated then please try to discuss that with us in the
+# upstream project IRC channel #checkbox on irc.freenode.net.
+
+# NOTE: one thing that you could do here, that makes a lot of sense,
+# is to compute version somehow. This may vary depending on the
+# context of your provider. Future version of PlainBox will offer git,
+# bzr and mercurial integration using the versiontools library
+# (optional)
+
+setup(
+    name='com.canonical.certification:openvino-toolkit-2404',
+    version="1.0",
+    description=N_("The com.canonical.certification:openvino-toolkit-2404 provider"),
+    gettext_domain="com_canonical_certification_openvino_toolkit_2404",
+)

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/category.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/category.pxu
@@ -1,0 +1,4 @@
+unit: category
+id: openvino
+_name: OpenVINO Python API validation
+

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
@@ -1,0 +1,101 @@
+id: host_npu
+category_id: openvino
+plugin: resource
+_description: Creates resource describing if NPU is available on the host
+estimated_duration: 2s
+command:
+  if ls /dev/accel/accel* > /dev/null 2>&1 ; then
+    echo "state: present"
+  else
+    echo "state: not-present"
+  fi
+
+id: host/NpuDevicePermissions
+category_id: openvino
+flags: simple
+_summary: Check that user has read and write access to NPU char device node(s)
+estimated_duration: 2s
+requires:
+  host_npu.state == 'present'
+command:
+  for node in "/dev/accel/accel*"; do
+    if ! test -r ${node} ; then
+      >&2 echo "Test failure: user must have read permissions to ${node}"
+      >&2 echo "Please run 'sudo usermod -a -G render $USER' then log out and back in"
+      >&2 echo "Then run 'sudo chown root:render ${node} && sudo chmod g+rw ${node}'"
+      exit 1
+    fi
+    if ! test -w ${node} ; then
+      >&2 echo "Test failure: user must have write permissions to ${node}"
+      >&2 echo "Please run 'sudo usermod -a -G render $USER' then log out and back in"
+      >&2 echo "Then run 'sudo chown root:render ${node} && sudo chmod g+rw ${node}'"
+      exit 1
+    fi
+  done
+  echo "Test success: user has read and write access to NPU device node(s) $(ls /dev/accel/accel*)"
+
+id: host_gpu
+category_id: openvino
+plugin: resource
+_description: Creates resource describing if GPU is available on the host
+estimated_duration: 2s
+command:
+  if ls /dev/dri/render* > /dev/null 2>&1 ; then
+    echo "state: present"
+  else
+    echo "state: not-present"
+  fi
+
+id: host/GpuDevicePermissions
+category_id: openvino
+flags: simple
+_summary: Check that user has read and write access to GPU char device node(s)
+estimated_duration: 2s
+requires:
+  host_gpu.state == 'present'
+command:
+  for node in "/dev/dri/render*"; do
+    if ! test -r ${node} ; then
+      >&2 echo "Test failure: user must have read permissions to ${node}"
+      >&2 echo "Please run 'sudo usermod -a -G render $USER' then log out and back in"
+      >&2 echo "Then run 'sudo chown root:render ${node} && sudo chmod g+rw ${node}'"
+      exit 1
+    fi
+    if ! test -w ${node} ; then
+      >&2 echo "Test failure: user must have write permissions to ${node}"
+      >&2 echo "Please run 'sudo usermod -a -G render $USER' then log out and back in"
+      >&2 echo "Then run 'sudo chown root:render ${node} && sudo chmod g+rw ${node}'"
+      exit 1
+    fi
+  done
+  echo "Test success: user has read and write access to GPU device node(s) $(ls /dev/dri/render*)"
+
+id: host/IntelGpuAvail
+category_id: openvino
+flags: simple
+_summary: Verify that an Intel GPU is available on the host
+estimated_duration: 2s
+requires: 
+  executable.name == 'intel_gpu_top'
+  host_gpu.state == 'present'
+command:
+  result=$(intel_gpu_top -L)
+  if [[ ${result} == *"pci:vendor=8086"* ]]; then
+      echo "Test success: Intel GPU available on host: ${result}"
+  else
+      >&2 echo "Test failure: "intel_gpu_top -L" reports no Intel GPUs: ${result}"
+      exit 1
+  fi
+
+id: python/devices_avail
+category_id: openvino
+flags: simple
+_summary: Check that we can use a CPU, NPU, and GPU with the OpenVINO Python API
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+  host_npu.state == 'present'
+  host_gpu.state == 'present'
+command:
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.validate-openvino

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
@@ -87,15 +87,189 @@ command:
       exit 1
   fi
 
-id: python/devices_avail
+id: python/devices_avail_cpu
 category_id: openvino
 flags: simple
-_summary: Check that we can use a CPU, NPU, and GPU with the OpenVINO Python API
+_summary: Check that we can use a CPU with the OpenVINO Python API
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  supported_devices=$(openvino-sample-consumer.validate-openvino)
+  if ! echo ${supported_devices} | grep -qw "CPU" ; then
+    >&2 echo "Test failure: CPU not detected by OpenVINO Python API."
+    exit 1
+  fi
+
+id: python/devices_avail_gpu
+category_id: openvino
+flags: simple
+_summary: Check that we can use a GPU with the OpenVINO Python API
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+  host_gpu.state == 'present'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  supported_devices=$(openvino-sample-consumer.validate-openvino)
+  if ! echo ${supported_devices} | grep -qw "GPU" ; then
+    >&2 echo "Test failure: GPU not detected by OpenVINO Python API."
+    exit 1
+  fi
+
+id: python/devices_avail_npu
+category_id: openvino
+flags: simple
+_summary: Check that we can use a NPU with the OpenVINO Python API
 estimated_duration: 5s
 requires:
   executable.name == 'openvino-sample-consumer.validate-openvino'
   host_npu.state == 'present'
-  host_gpu.state == 'present'
 command:
+  # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
-  openvino-sample-consumer.validate-openvino
+  supported_devices=$(openvino-sample-consumer.validate-openvino)
+  if ! echo ${supported_devices} | grep -qw "NPU" ; then
+    >&2 echo "Test failure: NPU not detected by OpenVINO Python API."
+    exit 1
+  fi
+
+id: gimp/clean_install_dirs
+category_id: openvino
+flags: simple
+_summary: Ensure gimp plugin dirs do not yet exist
+estimated_duration: 2s
+command:
+  CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
+  if [ -f ${CONFIG_FILE} ]; then
+    >&2 echo "Test failure: ${CONFIG_FILE} already exists!"
+    >&2 echo "In order to run the GIMP plugin tests you must first remove this file."
+    exit 1
+  fi
+  MODELS_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp
+  if [ -d ${MODELS_DIR} ]; then
+    >&2 echo "Test failure: ${MODELS_DIR} already exists!"
+    >&2 echo "In order to run the GIMP plugin tests you must first remove this directory."
+    exit 1
+  fi
+
+id: gimp/model_setup_empty_run
+category_id: openvino
+flags: simple
+_summary: Check that model setup app runs successfully
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-ai-plugins-gimp.model-setup'
+depends:
+  gimp/clean_install_dirs
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  # menu item 0 : exit stable diffusion model setup
+  echo "0" | openvino-ai-plugins-gimp.model-setup
+
+id: gimp/semseg_models_installed
+category_id: openvino
+flags: simple
+_summary: Check that semantic segmentation models are installed
+estimated_duration: 2s
+requires:
+  executable.name == 'openvino-ai-plugins-gimp.model-setup'
+depends:
+  gimp/model_setup_empty_run
+command:
+  SEMSEG_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp/weights/semseg-ov
+  file_cnt=$(ls ${SEMSEG_DIR} | wc -l)
+  if [ $file_cnt != "5" ]; then
+    >&2 echo "Test failure: expected 5 files in ${SEMSEG_DIR}, got ${file_cnt} instead."
+    exit 1
+  fi
+
+id: gimp/superresolution_models_installed
+category_id: openvino
+flags: simple
+_summary: Check that super resolution models are installed
+estimated_duration: 2s
+requires:
+  executable.name == 'openvino-ai-plugins-gimp.model-setup'
+depends:
+  gimp/model_setup_empty_run
+command:
+  SUPERRES_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp/weights/superresolution-ov
+  file_cnt=$(ls ${SUPERRES_DIR} | wc -l)
+  if [ $file_cnt != "7" ]; then
+    >&2 echo "Test failure: expected 7 files in ${SUPERRES_DIR}, got ${file_cnt} instead."
+    exit 1
+  fi
+
+id: gimp/gimp_openvino_config_installed
+category_id: openvino
+flags: simple
+_summary: Check that the GIMP OpenVINO config is installed
+estimated_duration: 2s
+requires:
+  executable.name == 'openvino-ai-plugins-gimp.model-setup'
+depends:
+  gimp/model_setup_empty_run
+command:
+  CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
+  if [ ! -f ${CONFIG_FILE} ]; then
+    >&2 echo "Test failure: ${CONFIG_FILE} does not exist!"
+    exit 1
+  fi
+
+id: gimp/devices_avail_cpu
+category_id: openvino
+flags: simple
+_summary: Check that we can use a CPU with the OpenVINO AI plugins for GIMP
+estimated_duration: 5s
+requires:
+  executable.name == 'jq'
+depends:
+  gimp/model_setup_empty_run
+command:
+  CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
+  supported_devices=$(cat ${CONFIG_FILE} | jq '.supported_devices[]')
+  if ! echo ${supported_devices} | grep -qw "CPU" ; then
+    >&2 echo "Test failure: CPU not supported by OpenVINO plugins for GIMP."
+    exit 1
+  fi
+
+id: gimp/devices_avail_gpu
+category_id: openvino
+flags: simple
+_summary: Check that we can use a GPU with the OpenVINO AI plugins for GIMP
+estimated_duration: 5s
+requires:
+  executable.name == 'jq'
+  host_gpu.state == 'present'
+depends:
+  gimp/model_setup_empty_run
+command:
+  CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
+  supported_devices=$(cat ${CONFIG_FILE} | jq '.supported_devices[]')
+  if ! echo ${supported_devices} | grep -qw "GPU" ; then
+    >&2 echo "Test failure: GPU not supported by OpenVINO plugins for GIMP."
+    exit 1
+  fi
+
+id: gimp/devices_avail_npu
+category_id: openvino
+flags: simple
+_summary: Check that we can use a NPU with the OpenVINO AI plugins for GIMP
+estimated_duration: 5s
+requires:
+  executable.name == 'jq'
+  host_npu.state == 'present'
+depends:
+  gimp/model_setup_empty_run
+command:
+  CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
+  supported_devices=$(cat ${CONFIG_FILE} | jq '.supported_devices[]')
+  if ! echo ${supported_devices} | grep -qw "NPU" ; then
+    >&2 echo "Test failure: GPU not supported by OpenVINO plugins for GIMP."
+    exit 1
+  fi

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
@@ -97,11 +97,12 @@ requires:
 command:
   # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
-  supported_devices=$(openvino-sample-consumer.validate-openvino)
+  supported_devices=$(openvino-sample-consumer.validate-openvino | tail -n1 | cut -f2 -d":")
   if ! echo ${supported_devices} | grep -qw "CPU" ; then
     >&2 echo "Test failure: CPU not detected by OpenVINO Python API."
     exit 1
   fi
+  echo "Test success: found CPU in supported devices: ${supported_devices}"
 
 id: python/devices_avail_gpu
 category_id: openvino
@@ -114,11 +115,12 @@ requires:
 command:
   # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
-  supported_devices=$(openvino-sample-consumer.validate-openvino)
+  supported_devices=$(openvino-sample-consumer.validate-openvino | tail -n1 | cut -f2 -d":")
   if ! echo ${supported_devices} | grep -qw "GPU" ; then
     >&2 echo "Test failure: GPU not detected by OpenVINO Python API."
     exit 1
   fi
+  echo "Test success: found GPU in supported devices: ${supported_devices}"
 
 id: python/devices_avail_npu
 category_id: openvino
@@ -131,11 +133,12 @@ requires:
 command:
   # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
-  supported_devices=$(openvino-sample-consumer.validate-openvino)
+  supported_devices=$(openvino-sample-consumer.validate-openvino | tail -n1 | cut -f2 -d":")
   if ! echo ${supported_devices} | grep -qw "NPU" ; then
     >&2 echo "Test failure: NPU not detected by OpenVINO Python API."
     exit 1
   fi
+  echo "Test success: found NPU in supported devices: ${supported_devices}"
 
 id: gimp/clean_install_dirs
 category_id: openvino
@@ -155,6 +158,7 @@ command:
     >&2 echo "In order to run the GIMP plugin tests you must first remove this directory."
     exit 1
   fi
+  echo "Test success: ${CONFIG_FILE} and ${MODELS_DIR} do not exist."
 
 id: gimp/model_setup_empty_run
 category_id: openvino
@@ -170,48 +174,45 @@ command:
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
   # menu item 0 : exit stable diffusion model setup
   echo "0" | openvino-ai-plugins-gimp.model-setup
+  echo "Test success: model setup application ran successfully."
 
 id: gimp/semseg_models_installed
 category_id: openvino
 flags: simple
 _summary: Check that semantic segmentation models are installed
 estimated_duration: 2s
-requires:
-  executable.name == 'openvino-ai-plugins-gimp.model-setup'
 depends:
   gimp/model_setup_empty_run
 command:
   SEMSEG_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp/weights/semseg-ov
   file_cnt=$(ls ${SEMSEG_DIR} | wc -l)
-  if [ $file_cnt != "5" ]; then
+  if [ ${file_cnt} != "5" ]; then
     >&2 echo "Test failure: expected 5 files in ${SEMSEG_DIR}, got ${file_cnt} instead."
     exit 1
   fi
+  echo "Test success: semantic segmentation models found in expected location."
 
 id: gimp/superresolution_models_installed
 category_id: openvino
 flags: simple
 _summary: Check that super resolution models are installed
 estimated_duration: 2s
-requires:
-  executable.name == 'openvino-ai-plugins-gimp.model-setup'
 depends:
   gimp/model_setup_empty_run
 command:
   SUPERRES_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp/weights/superresolution-ov
   file_cnt=$(ls ${SUPERRES_DIR} | wc -l)
-  if [ $file_cnt != "7" ]; then
+  if [ ${file_cnt} != "7" ]; then
     >&2 echo "Test failure: expected 7 files in ${SUPERRES_DIR}, got ${file_cnt} instead."
     exit 1
   fi
+  echo "Test success: super resolution models found in expected location."
 
 id: gimp/gimp_openvino_config_installed
 category_id: openvino
 flags: simple
 _summary: Check that the GIMP OpenVINO config is installed
 estimated_duration: 2s
-requires:
-  executable.name == 'openvino-ai-plugins-gimp.model-setup'
 depends:
   gimp/model_setup_empty_run
 command:
@@ -220,6 +221,7 @@ command:
     >&2 echo "Test failure: ${CONFIG_FILE} does not exist!"
     exit 1
   fi
+  echo "Test success: config for OpenVINO AI Plugins for GIMP found in expected location."
 
 id: gimp/devices_avail_cpu
 category_id: openvino
@@ -230,6 +232,7 @@ requires:
   executable.name == 'jq'
 depends:
   gimp/model_setup_empty_run
+  gimp/gimp_openvino_config_installed
 command:
   CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
   supported_devices=$(cat ${CONFIG_FILE} | jq '.supported_devices[]')
@@ -237,6 +240,7 @@ command:
     >&2 echo "Test failure: CPU not supported by OpenVINO plugins for GIMP."
     exit 1
   fi
+  printf "Test success: found CPU in supported devices:\n${supported_devices}"
 
 id: gimp/devices_avail_gpu
 category_id: openvino
@@ -248,6 +252,7 @@ requires:
   host_gpu.state == 'present'
 depends:
   gimp/model_setup_empty_run
+  gimp/gimp_openvino_config_installed
 command:
   CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
   supported_devices=$(cat ${CONFIG_FILE} | jq '.supported_devices[]')
@@ -255,6 +260,7 @@ command:
     >&2 echo "Test failure: GPU not supported by OpenVINO plugins for GIMP."
     exit 1
   fi
+  printf "Test success: found GPU in supported devices:\n${supported_devices}"
 
 id: gimp/devices_avail_npu
 category_id: openvino
@@ -266,10 +272,65 @@ requires:
   host_npu.state == 'present'
 depends:
   gimp/model_setup_empty_run
+  gimp/gimp_openvino_config_installed
 command:
   CONFIG_FILE=${SNAP_REAL_HOME}/snap/openvino-ai-plugins-gimp/common/gimp_openvino_config.json
   supported_devices=$(cat ${CONFIG_FILE} | jq '.supported_devices[]')
   if ! echo ${supported_devices} | grep -qw "NPU" ; then
-    >&2 echo "Test failure: GPU not supported by OpenVINO plugins for GIMP."
+    >&2 echo "Test failure: NPU not supported by OpenVINO plugins for GIMP."
     exit 1
   fi
+  printf "Test success: found NPU in supported devices:\n${supported_devices}"
+
+id: gimp/model_setup_install_lcm_model
+category_id: openvino
+flags: simple
+_summary: Check that model setup app can install a model
+estimated_duration: 5m
+requires:
+  executable.name == 'openvino-ai-plugins-gimp.model-setup'
+depends:
+  gimp/clean_install_dirs
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  # menu item 2 : install Stable Diffusion 1.5 LCM
+  # menu item 0 : exit stable diffusion model setup
+  echo "2 0" | openvino-ai-plugins-gimp.model-setup
+  echo "Test success: installed stable diffusion LCM model using model-setup application."
+
+id: gimp/stable_diffusion_models_installed
+category_id: openvino
+flags: simple
+_summary: Check that stable diffusion models are installed
+estimated_duration: 2s
+depends:
+  gimp/model_setup_install_lcm_model
+command:
+  SD_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp/weights/stable-diffusion-ov/stable-diffusion-1.5/square_lcm
+  # text_encoder.bin, unet.bin, vae_docoder.bin
+  bin_file_cnt=$(ls ${SD_DIR} | grep ".bin" | wc -l)
+  if [ ${bin_file_cnt} != "3" ]; then
+    >&2 echo "Test failure: expected 3 .bin files in ${SD_DIR}, got ${bin_file_cnt} instead."
+    exit 1
+  fi
+  echo "Test success: LCM models are installed in the expected location."
+
+id: gimp/stable_diffusion_npu_models_installed
+category_id: openvino
+flags: simple
+_summary: Check that stable diffusion models compiled for NPU are installed
+estimated_duration: 2s
+depends:
+  gimp/model_setup_install_lcm_model
+requires:
+  host_npu.state == 'present'
+command:
+  SD_DIR=${SNAP_REAL_HOME}/.local/share/openvino-ai-plugins-gimp/weights/stable-diffusion-ov/stable-diffusion-1.5/square_lcm
+  # text_encoder.blob, unet.blob
+  blob_file_cnt=$(ls ${SD_DIR} | grep ".blob" | wc -l)
+  if [ ${blob_file_cnt} != "2" ]; then
+    >&2 echo "Test failure: expected 2 .blob files in ${SD_DIR}, got ${blob_file_cnt} instead."
+    exit 1
+  fi
+  echo "Test success: LCM models compiled for the NPU are installed in the expected location."

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
@@ -18,7 +18,8 @@ estimated_duration: 2s
 requires:
   host_npu.state == 'present'
 command:
-  for node in "/dev/accel/accel*"; do
+  for node in $(ls /dev/accel/accel*); do
+    echo "[INFO] Checking node ${node}"
     if ! test -r ${node} ; then
       >&2 echo "Test failure: user must have read permissions to ${node}"
       >&2 echo "Please run 'sudo usermod -a -G render $USER' then log out and back in"
@@ -54,7 +55,8 @@ estimated_duration: 2s
 requires:
   host_gpu.state == 'present'
 command:
-  for node in "/dev/dri/render*"; do
+  for node in $(ls /dev/dri/render*); do
+    echo "[INFO] Checking node ${node}"
     if ! test -r ${node} ; then
       >&2 echo "Test failure: user must have read permissions to ${node}"
       >&2 echo "Please run 'sudo usermod -a -G render $USER' then log out and back in"

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/test-plan.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/test-plan.pxu
@@ -4,6 +4,7 @@ _name: OpenVINO Python API tests
 include:
     host/.*
     python/.*
+    gimp/.*
 bootstrap_include:
     com.canonical.certification::executable
     com.canonical.certification::snap

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/test-plan.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/test-plan.pxu
@@ -1,0 +1,10 @@
+id: openvino-python
+unit: test plan
+_name: OpenVINO Python API tests
+include:
+    host/.*
+    python/.*
+bootstrap_include:
+    com.canonical.certification::executable
+    com.canonical.certification::snap
+

--- a/checkbox/snap/hooks/install
+++ b/checkbox/snap/hooks/install
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+set -e
+snapctl set slave=enabled
+
+echo "$(id -un 1000 2>/dev/null || id -un 1001 2>/dev/null || echo ubuntu) ALL=(ALL:ALL) NOPASSWD: ALL" > /etc/sudoers.d/checkbox
+
+mkdir -p /etc/polkit-1/localauthority/50-local.d
+cat <<EOF > /etc/polkit-1/localauthority/50-local.d/com.canonical.certification.checkbox.pkla
+[Checkbox]
+Identity=unix-group:sudo
+Action=org.freedesktop.NetworkManager.*
+ResultAny=yes
+ResultInactive=yes
+ResultActive=yes
+EOF

--- a/checkbox/snap/hooks/remove
+++ b/checkbox/snap/hooks/remove
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+rm -f /etc/sudoers.d/checkbox
+rm -f /etc/polkit-1/localauthority/50-local.d/com.canonical.certification.checkbox.pkla || /bin/true

--- a/checkbox/snap/snapcraft.yaml
+++ b/checkbox/snap/snapcraft.yaml
@@ -1,0 +1,65 @@
+name: checkbox-openvino-toolkit-2404
+summary: Checkbox tests for the openvino-toolkit-2404 snap
+description: |
+  Collection of tests for the OpenVINO Python API
+version: '1.0.0'
+confinement: classic
+grade: stable
+
+base: core22
+
+# Here are the available applications of the NPU checkbox provider snap
+# To run : snap run checkbox-npu.<app>
+#
+# checkbox-cli:
+#   - checkbox client, can be used to talk to the checkbox daemon
+# remote-slave:
+#   - checkbox slave daemon that will the responsible for running the test sesssion
+#     in the remote fashion (through checkbox-cli)
+# shell:
+#   - give shell access to the provider snap
+# test-runner / test-runner-automated:
+#   - execute all provider tests inside the snap environment
+#     the test execution is standalone and does not depend on the remote-slave daemon
+# install-full-deps:
+#   - install all depedencies needed for provider jobs
+apps:
+  checkbox-cli:
+    command-chain: [bin/wrapper_local]
+    command: bin/checkbox-cli-wrapper
+  remote-slave:
+    command-chain: [bin/wrapper_local]
+    command: bin/checkbox-cli-wrapper slave
+    daemon: simple
+    restart-condition: always
+  shell:
+    command-chain: [bin/wrapper_local]
+    command: bin/shell-wrapper
+  test-runner:
+    command-chain: [bin/wrapper_local]
+    command: bin/test-runner
+  test-runner-automated:
+    command-chain: [bin/wrapper_local]
+    command: bin/test-runner-automated
+  install-full-deps:
+    command: bin/install-full-deps
+
+parts:
+  checkbox-provider-openvino-toolkit-2404:
+    plugin: dump
+    source: ./checkbox-provider-openvino-toolkit-2404
+    source-type: local
+    build-snaps:
+      - checkbox-provider-tools
+      - checkbox22
+    override-build: |
+      for path in $(find "/snap/checkbox22/current/providers/" -mindepth 1 -maxdepth 1 -type d); do export PROVIDERPATH=$path${PROVIDERPATH:+:$PROVIDERPATH}; done
+      checkbox-provider-tools validate
+      checkbox-provider-tools build
+      checkbox-provider-tools install --layout=relocatable --prefix=/providers/checkbox-provider-openvino-toolkit-2404 --root="$SNAPCRAFT_PART_INSTALL"
+
+  bin:
+    plugin: dump
+    source: bin
+    organize:
+      '*': bin/

--- a/checkbox/snap/snapcraft.yaml
+++ b/checkbox/snap/snapcraft.yaml
@@ -8,8 +8,8 @@ grade: stable
 
 base: core22
 
-# Here are the available applications of the NPU checkbox provider snap
-# To run : snap run checkbox-npu.<app>
+# Here are the available applications of the OpenVINO Tookit 2404 checkbox provider snap
+# To run : snap run checkbox-openvino-toolkit-2404.<app>
 #
 # checkbox-cli:
 #   - checkbox client, can be used to talk to the checkbox daemon

--- a/sample-consumer/README.md
+++ b/sample-consumer/README.md
@@ -1,0 +1,27 @@
+# Sample content consumer app for openvino-toolkit-2404
+
+## Building
+
+```
+snapcraft
+```
+
+## Installing
+
+```
+sudo snap install --dangerous ./openvino-sample-consumer_1.0.0_amd64.snap
+```
+
+## Connecting snapd interfaces
+
+```
+sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs
+sudo snap connect openvino-sample-consumer:openvino-libs openvino-toolkit-2404:openvino-libs
+```
+
+The following should autoconnect:
+
+```
+sudo snap connect openvino-sample-consumer:intel-npu intel-npu-driver:intel-npu-plug
+sudo snap connect openvino-sample-consumer:opengl
+```

--- a/sample-consumer/snap/snapcraft.yaml
+++ b/sample-consumer/snap/snapcraft.yaml
@@ -1,0 +1,146 @@
+name: openvino-sample-consumer
+base: core24
+summary: Sample OpenVINO content consumer for testing and validation
+description: |
+  This snap is used for validating the openvino-toolkit-2404 snap.
+version: 1.0.0
+
+grade: devel
+confinement: strict
+
+platforms:
+  # only for architecture of host
+  arm64:
+  amd64:
+
+plugs:
+  intel-npu:
+    interface: custom-device
+    custom-device: intel-npu-device
+  npu-libs:
+    interface: content
+    content: npu-libs-2404
+    target: $SNAP/npu-libs
+  openvino-libs:
+    interface: content
+    content: openvino-libs-2404
+    target: $SNAP/openvino
+
+apps:
+  validate-openvino:
+    command-chain: ["command-chain/openvino-launch"]
+    command: usr/bin/python3 $SNAP/validate_openvino.py
+    plugs:
+      - opengl # Intel GPU access (device nodes)
+      - intel-npu # Intel NPU access (device node)
+      - npu-libs # Intel NPU access (libs)
+      - openvino-libs # OpenVINO runtime
+    environment:
+      # Intel OpenCL libs install to /usr/local/lib
+      LD_LIBRARY_PATH: $SNAP/npu-libs:$SNAP/usr/local/lib:$LD_LIBRARY_PATH
+      PYTHONPATH: $SNAP/lib/python3.12/site-packages:$PYTHONPATH
+      OCL_ICD_VENDORS: $SNAP/etc/OpenCL/vendors
+
+parts:
+  validate-openvino:
+    source: src/
+    plugin: dump
+    stage:
+      - validate_openvino.py
+
+  python-deps:
+    source: src/
+    plugin: python
+    python-packages: 
+      - pytest
+      - numpy>=1.16.6,<2.3.0 # openvino dep
+      - openvino-telemetry>=2023.2.1 # openvino dep
+      - packaging # openvino dep
+    stage-packages:
+      - python3-minimal # python interpreter
+      - python3.12-minimal # python interpreter
+      - libva2 # openvino gpu plugin dep
+      - libgl1 # opencv-python dep
+      - libglu1-mesa # opencv-python dep
+      - libxcb1 # opencv-python dep
+      - libice6 # opencv-python dep
+      - libsm6 # opencv-python dep
+      - libx11-6 # opencv-python dep
+      - libxext6 # opencv-python dep
+    stage:
+      - -usr/lib/x86_64-linux-gnu/libGLU.so.1.3.1
+      - -usr/lib/x86_64-linux-gnu/libGLX_mesa.so.0.0.0
+      - -usr/lib/x86_64-linux-gnu/libicuio.so.74.2
+      - -usr/lib/x86_64-linux-gnu/libicutest.so.74.2
+      - -usr/lib/x86_64-linux-gnu/libvulkan.so.1.3.275
+      - -usr/lib/x86_64-linux-gnu/libOpenGL.so.0.0.0
+      - -usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
+      - -usr/lib/x86_64-linux-gnu/libXxf86vm.so.1.0.0
+      - -usr/lib/x86_64-linux-gnu/libicutu.so.74.2
+      - -usr/lib/x86_64-linux-gnu/libxcb-dri2.so.0.0.0
+      - -usr/lib/x86_64-linux-gnu/libxcb-glx.so.0.0.0
+      - -usr/lib/x86_64-linux-gnu/libxcb-present.so.0.0.0
+      - -usr/lib/x86_64-linux-gnu/libxcb-randr.so.0.1.0
+      - -usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
+      - -usr/lib/x86_64-linux-gnu/libxcb-sync.so.1.0.0
+      - -usr/lib/x86_64-linux-gnu/libxcb-xfixes.so.0.0.0
+      - -usr/lib/x86_64-linux-gnu/libxshmfence.so.1.0.0
+      - -usr/lib/x86_64-linux-gnu/libicui18n.so.74.2
+
+  opencl-driver:
+    # Includes all the compute runtime and OpenCL bits needed for Intel GPU support
+    plugin: nil
+    build-packages:
+      - wget
+    override-build: |
+      mkdir -p neo
+      cd neo
+      # Install Intel graphics compiler and compute runtime
+      # This is required to enable GPU support for OpenVINO
+      # https://docs.openvino.ai/2024/get-started/configurations/configurations-intel-gpu.html
+      wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-core-2_2.5.6+18417_amd64.deb
+      wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-opencl-2_2.5.6+18417_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-level-zero-gpu_1.6.32224.5_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-opencl-icd_24.52.32224.5_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/libigdgmm12_22.5.5_amd64.deb
+      dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
+      # update paths to the Intel Installable Client Drivers (ICDs) for OpenCL
+      intel_icd="${CRAFT_PART_INSTALL}"/etc/OpenCL/vendors/intel.icd
+      intel_icd_so_path=$(cat ${intel_icd})
+      base_path="/snap/${SNAPCRAFT_PROJECT_NAME}/current"
+      echo "${base_path}""${intel_icd_so_path}" > "${intel_icd}"
+      intel_legacy1_icd="${CRAFT_PART_INSTALL}"/etc/OpenCL/vendors/intel_legacy1.icd
+      if [ -f ${intel_legacy1_icd} ]; then
+        intel_legacy1_icd_so_path=$(cat ${intel_legacy1_icd})
+        echo "${base_path}""${intel_legacy1_icd_so_path}" > "${intel_legacy1_icd}"
+      fi
+      # fix broken sym links
+      cd "${CRAFT_PART_INSTALL}"
+      ln -sf "${base_path}"/usr/bin/ocloc-24.39.1 etc/alternatives/ocloc
+      ln -sf "${base_path}"/etc/alternatives/ocloc usr/bin/ocloc
+      craftctl default
+
+  command-chain-openvino:
+    plugin: dump
+    source-type: git
+    source: https://github.com/canonical/openvino-toolkit-snap.git
+    source-tag: 2024.6.0-0
+    stage:
+      - command-chain/openvino-launch
+
+lint:
+  ignore:
+    - library:
+      # These are needed but are flagged
+      # by the linter because they are not
+      # explicitly linked to any binary or
+      # shared object
+      - openvino/usr/runtime/3rdparty/tbb/lib/libtbbbind*
+      - openvino/usr/runtime/3rdparty/tbb/lib/libtbbmalloc*
+      - openvino/usr/runtime/3rdparty/tbb/lib/libhwloc*
+      - usr/lib/x86_64-linux-gnu/libva.so.*
+      - usr/lib/x86_64-linux-gnu/libze_intel_gpu.so.*
+      - usr/local/lib/libiga64.so*
+      - usr/local/lib/libigc.so.*
+      - usr/local/lib/libigdfcl.so.*
+      - usr/local/lib/libopencl-clang*

--- a/sample-consumer/src/validate_openvino.py
+++ b/sample-consumer/src/validate_openvino.py
@@ -1,0 +1,6 @@
+import openvino as ov
+
+core = ov.Core()
+devices = core.get_available_devices()
+
+print(f"Supported devices: {devices}")


### PR DESCRIPTION
This adds a checkbox provider for testing the `openvino-toolkit-2404` snap and runs the tests through testflinger on PRs and merges to the `openvino-toolkit-2404` branch.

The checkbox tests use a few content consumer snaps for testing:

* A sample app that tests the OpenVINO Python API, specifically to verify that an Intel CPU, GPU, and NPU can be detected
* `openvino-ai-plugins-gimp`

Feel free to review anything, but probably the most important bits are the checkbox `jobs.pxu`, READMEs, snapcraft yaml files, and GitHub action related files.

Internal Jira card: [PEK-1317](https://warthogs.atlassian.net/browse/PEK-1317)

[PEK-1317]: https://warthogs.atlassian.net/browse/PEK-1317?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ