### PR TITLE
Update cmake build to use system deps and standard install paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+# Snap build artifacts
 *.snap
+# logs from snapcraft remote-build
+*.txt

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -23,7 +23,7 @@ fi
 
 sudo DEBIAN_FRONTEND=noninteractive apt install -y intel-gpu-tools jq
 sudo snap install intel-npu-driver --beta
-sudo snap install openvino-ai-plugins-gimp --beta
+sudo snap install openvino-ai-plugins-gimp --edge
 
 # the content interfaces require manual connection
 sudo snap connect openvino-sample-consumer:npu-libs intel-npu-driver:npu-libs

--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -7,18 +7,12 @@
 # and emits a warning if a node is inaccessible.
 #
 
-# Save positional args in a new variable as setupvars.sh consumes $@
-cmd=("$@")
-
-# Source OpenVINO script to export environment vars needed at runtime
-if [ -f "${SNAP}/openvino/usr/setupvars.sh" ]; then
-  source "${SNAP}/openvino/usr/setupvars.sh"
-else
-  echo "Warning: OpenVINO command-chain script not found."
+CONTENT_PATH="${SNAP}/openvino"
+if [ ! -d "${CONTENT_PATH}" ]; then
+  echo "Warning: ${CONTENT_PATH} not present inside ${SNAP_NAME} snap. Please connect the content interface at this path."
 fi
-
-# libOpenCL shared objects distributed with OpenVINO snap
 export LD_LIBRARY_PATH="${SNAP}/openvino/usr/lib/x86_64-linux-gnu":$LD_LIBRARY_PATH
+export PYTHONPATH="${SNAP}/openvino/usr/lib/python3/dist-packages":$PYTHONPATH
 
 # Check user access to Intel accelerator devices (GPU and NPU)
 check_user_access() {
@@ -53,4 +47,4 @@ check_user_access() {
 check_user_access GPU /dev/dri/render render
 check_user_access NPU /dev/accel/accel render
 
-exec "${cmd[@]}"
+exec "$@"

--- a/sample-consumer/snap/snapcraft.yaml
+++ b/sample-consumer/snap/snapcraft.yaml
@@ -124,7 +124,8 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2024.6.0-0
+    source-branch: frenchwr/cmake-best-practices
+    #source-tag: 2024.6.0-0
     stage:
       - command-chain/openvino-launch
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,7 +10,6 @@ adopt-info: openvino
 
 platforms:
   arm64:
-    build-on: [amd64]
   amd64:
 
 # the recommended mountpoint for the content is /openvino
@@ -31,10 +30,19 @@ parts:
       - -DENABLE_PYTHON=ON
       - -DPython3_EXECUTABLE=/usr/bin/python3.12
       - -DCMAKE_INSTALL_PREFIX=/usr
+      - -DENABLE_SYSTEM_TBB=ON
+      - -DENABLE_SYSTEM_SNAPPY=ON
+      - -DENABLE_SNAPPY_COMPRESSION=ON
+      - -DCPACK_GENERATOR=DEB
+      - -DENABLE_SAMPLES=OFF
+      - -DENABLE_PYTHON_PACKAGING=ON
     override-pull: |
       craftctl default
       git submodule update --init --recursive
       craftctl set version="$(git describe --tags)"
+    override-build: |
+      craftctl default
+      rm -rf ${CRAFT_PART_INSTALL}/usr/{share,include,bin}
     build-packages:
       - ca-certificates
       - file
@@ -42,8 +50,6 @@ parts:
       - ninja-build
       - scons
       - ccache
-      - gcc-multilib
-      - g++-multilib
       - pkgconf
       - git
       - shellcheck
@@ -66,16 +72,21 @@ parts:
       - libffi-dev
       - python3-enchant
       - wget
+      - libsnappy-dev
     stage-packages:
       - ocl-icd-libopencl1
+      - libtbb12
+      - libsnappy1v5
 
 lint:
   ignore:
     - library:
-      # These are needed but are flagged
-      # by the linter because they are not
-      # explicitly linked to any binary or
-      # shared object
-      - usr/runtime/3rdparty/tbb/lib/libtbbbind*
-      - usr/runtime/3rdparty/tbb/lib/libtbbmalloc*
-      - usr/runtime/3rdparty/tbb/lib/libhwloc.so.15.6.4
+      # OpenVINO libs consumed by other snaps
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libopenvino*
+      # Linked by libopenvino_tensorflow_frontend
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libsnappy*
+      # Not explicitly linked but dlopen'd
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libtbbbind*
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libtbbmalloc*
+      # Linked by libtbbbind
+      - usr/lib/${CRAFT_ARCH_TRIPLET_BUILD_FOR}/libhwloc*


### PR DESCRIPTION
This makes a handful of updates to OpenVINO's cmake build configuration based on Intel's recommendation. 

The changes to standard installation paths allowed the `setupvars.sh` dependency to be removed but required the command-chain script to also be updated. Since this `command-chain` script is consumed by other applications it also requires minor updates to content consumer snaps...I have these changes published in `openvino-ai-plugins-gimp`'s `edge` channel, which I have included in the checkbox testing both on `hercules` and in this PR to be run through testflinger.

I also transitioned to using `snapcraft remote-build` for the `arm64` builds as I realized the previous method for cross-compiling from a `amd64` host had several issues, including the AMD64 versions of staged apt packages inside the snap.

Internal Jira card: [PEK-1597](https://warthogs.atlassian.net/browse/PEK-1597)

[PEK-1597]: https://warthogs.atlassian.net/browse/PEK-1597?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ