### PR TITLE
Improve Intel hardware checks

### DIFF
--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -28,7 +28,7 @@ node_is_intel_gpu() {
 # Check user access to Intel accelerator devices (GPU and NPU)
 check_user_access() {
   node=$1
-  if echo "${node}" | grep -qw render; then
+  if echo "${node}" | grep -q render; then
     if ! node_is_intel_gpu "${node}"; then
       return 0 # non-Intel GPUs unsupported
     fi

--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -8,8 +8,8 @@
 #
 
 CONTENT_PATH="${SNAP}/openvino"
-if [ ! -d "${CONTENT_PATH}" ]; then
-  echo "Warning: ${CONTENT_PATH} not present inside ${SNAP_NAME} snap. Please connect the content interface at this path."
+if [ ! -d "${CONTENT_PATH}" ] && grep -qw "GenuineIntel" /proc/cpuinfo; then
+  echo "Warning: ${CONTENT_PATH} not present inside ${SNAP_NAME} snap. Please install the snap using 'sudo snap install openvino-toolkit-2404 --beta' and restart the application."
 fi
 export LD_LIBRARY_PATH="${SNAP}/openvino/usr/lib/$(uname -m)-linux-gnu":$LD_LIBRARY_PATH
 export PYTHONPATH="${SNAP}/openvino/usr/lib/python3/dist-packages":$PYTHONPATH
@@ -31,7 +31,7 @@ check_user_access() {
   node=$1
   if echo "${node}" | grep -q render; then
     if ! node_is_intel_gpu "${node}"; then
-      return 0 # non-Intel GPUs unsupported
+      return # non-Intel GPUs unsupported
     fi
     device_type="GPU"
   else

--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -41,22 +41,24 @@ check_user_access() {
   if ! id -nGz "${USER}" | grep -qzxF render; then
     echo "Warning: to use the ${device_type} plugin, the user must be in the render group."
     echo "Please run 'sudo usermod -a -G render ${USER}' then log out and back in."
-    return 0
+    return
   fi
 
   if ! test -r "${node}" || ! test -w "${node}"; then
     echo "Warning: to use device ${node} with the ${device_type} plugin, the user must have read and write access to ${node}."
     echo "Please run 'sudo chown root:render ${node} && sudo chmod g+rw ${node}'."
     echo "Also confirm (run 'snap connections') that snap interfaces required to access ${node} are connected."
+    return
   fi
 }
 
+# handle cases where no render or accel nodes present
+shopt -s nullglob
+
 for node in /dev/dri/render*; do
-  [[ -e "${node}" ]] || break
   check_user_access "${node}"
 done
 for node in /dev/accel/accel*; do
-  [[ -e "${node}" ]] || break
   check_user_access "${node}"
 done
 

--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -14,40 +14,48 @@ fi
 export LD_LIBRARY_PATH="${SNAP}/openvino/usr/lib/$(uname -m)-linux-gnu":$LD_LIBRARY_PATH
 export PYTHONPATH="${SNAP}/openvino/usr/lib/python3/dist-packages":$PYTHONPATH
 
-# Check user access to Intel accelerator devices (GPU and NPU)
-check_user_access() {
-  if [ $# -ne 3 ]; then
-    echo "Unable to check user access to device accelerator(s)."
-    return 0
+# Check if device node is an Intel GPU
+node_is_intel_gpu() {
+  node=$1
+  render_device_name=$(echo "{$node}" | cut -f4 -d"/") # e.g. renderD128
+  gpu_info=$(intel_gpu_top -L | grep -B1 -w "${render_device_name}")
+  if echo "${gpu_info}" | grep -qw "pci:vendor=8086"; then
+    return 0 # this node is an Intel GPU
   fi
-  device_type=$1
-  glob_path=$2 # /dev/dri/card, /dev/dri/render, or /dev/accel/accel
-  required_group=$3
-
-  if ! compgen -G "${glob_path}"* > /dev/null; then
-    return 0 # skip as there is no device on the host
-  fi
-
-  if ! id -nGz "${USER}" | grep -qzxF "${required_group}"; then
-    echo "Warning: to use the ${device_type} plugin, the user must be in the ${required_group} group."
-    echo "Please run 'sudo usermod -a -G ${required_group} ${USER}' then log out and back in."
-    return 0
-  fi
-
-  for node in "${glob_path}"*; do
-    if ! test -r "${node}" || ! test -w "${node}"; then
-      echo "Warning: to use device ${node} with the ${device_type} plugin, the user must have read and write access to ${node}."
-      echo "Please run 'sudo chown root:${required_group} ${node} && sudo chmod g+rw ${node}'."
-      echo "Also confirm (run 'snap connections') that snap interfaces required to access ${node} are connected."
-      return 0
-    fi
-  done
+  return 1 # not an Intel GPU
 }
 
-# OpenVINO only supports Intel GPU and NPU for acceleration
-if [ "$(uname -m)" = "x86_64" ]; then
-  check_user_access GPU /dev/dri/render render
-  check_user_access NPU /dev/accel/accel render
-fi
+# Check user access to Intel accelerator devices (GPU and NPU)
+check_user_access() {
+  node=$1
+  if echo "${node}" | grep -qw render; then
+    if ! node_is_intel_gpu "${node}"; then
+      return 0 # non-Intel GPUs unsupported
+    fi
+    device_type="GPU"
+  else
+    device_type="NPU"
+  fi
+
+  if ! test -r "${node}" || ! test -w "${node}"; then
+    echo "Warning: to use device ${node} with the ${device_type} plugin, the user must have read and write access to ${node}."
+    echo "Please run 'sudo chown root:render ${node} && sudo chmod g+rw ${node}'."
+    echo "Also confirm (run 'snap connections') that snap interfaces required to access ${node} are connected."
+  fi
+
+  if ! id -nGz "${USER}" | grep -qzxF render; then
+    echo "Warning: to use the ${device_type} plugin, the user must be in the render group."
+    echo "Please run 'sudo usermod -a -G render ${USER}' then log out and back in."
+  fi
+}
+
+for node in /dev/dri/render*; do
+  [[ -e "${node}" ]] || break
+  check_user_access "${node}"
+done
+for node in /dev/accel/accel*; do
+  [[ -e "${node}" ]] || break
+  check_user_access "${node}"
+done
 
 exec "$@"

--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -38,15 +38,16 @@ check_user_access() {
     device_type="NPU"
   fi
 
+  if ! id -nGz "${USER}" | grep -qzxF render; then
+    echo "Warning: to use the ${device_type} plugin, the user must be in the render group."
+    echo "Please run 'sudo usermod -a -G render ${USER}' then log out and back in."
+    return 0
+  fi
+
   if ! test -r "${node}" || ! test -w "${node}"; then
     echo "Warning: to use device ${node} with the ${device_type} plugin, the user must have read and write access to ${node}."
     echo "Please run 'sudo chown root:render ${node} && sudo chmod g+rw ${node}'."
     echo "Also confirm (run 'snap connections') that snap interfaces required to access ${node} are connected."
-  fi
-
-  if ! id -nGz "${USER}" | grep -qzxF render; then
-    echo "Warning: to use the ${device_type} plugin, the user must be in the render group."
-    echo "Please run 'sudo usermod -a -G render ${USER}' then log out and back in."
   fi
 }
 

--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -13,11 +13,12 @@ if [ ! -d "${CONTENT_PATH}" ]; then
 fi
 export LD_LIBRARY_PATH="${SNAP}/openvino/usr/lib/$(uname -m)-linux-gnu":$LD_LIBRARY_PATH
 export PYTHONPATH="${SNAP}/openvino/usr/lib/python3/dist-packages":$PYTHONPATH
+export PATH="${SNAP}/openvino/usr/bin":$PATH
 
 # Check if device node is an Intel GPU
 node_is_intel_gpu() {
   node=$1
-  render_device_name=$(echo "{$node}" | cut -f4 -d"/") # e.g. renderD128
+  render_device_name=$(echo "${node}" | cut -f4 -d"/") # e.g. renderD128
   gpu_info=$(intel_gpu_top -L | grep -B1 -w "${render_device_name}")
   if echo "${gpu_info}" | grep -qw "pci:vendor=8086"; then
     return 0 # this node is an Intel GPU

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,6 +77,7 @@ parts:
       - ocl-icd-libopencl1
       - libtbb12
       - libsnappy1v5
+      - intel-gpu-tools
 
 lint:
   ignore:


### PR DESCRIPTION
This updates the `command-chain` script to improve Intel hardware detection using `intel_gpu_top`, which is important for a good user experience as non-Intel hardware (e.g. NVIDIA or AMD GPUs) is not supported by the GIMP plugins.