### PR TITLE
Bugfixes related to introducing intel_gpu_top command inside snap

### DIFF
--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -17,6 +17,11 @@ export PATH="${SNAP}/openvino/usr/bin":$PATH
 
 # Check if device node is an Intel GPU
 node_is_intel_gpu() {
+  if ! command -v intel_gpu_top >/dev/null 2>&1; then
+    # intel_gpu_top command unavailable for ARM64
+    # Assume for an ARM64 system that a GPU is not from Intel
+    return 1
+  fi
   node=$1
   render_device_name=$(echo "${node}" | cut -f4 -d"/") # e.g. renderD128
   gpu_info=$(intel_gpu_top -L | grep -B1 -w "${render_device_name}")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -42,7 +42,7 @@ parts:
       craftctl set version="$(git describe --tags)"
     override-build: |
       craftctl default
-      rm -rf ${CRAFT_PART_INSTALL}/usr/{share,include,bin}
+      rm -rf ${CRAFT_PART_INSTALL}/usr/{share,include}
     build-packages:
       - ca-certificates
       - file

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -77,7 +77,8 @@ parts:
       - ocl-icd-libopencl1
       - libtbb12
       - libsnappy1v5
-      - intel-gpu-tools
+      - to amd64:
+        - intel-gpu-tools
 
 lint:
   ignore:


### PR DESCRIPTION
* Do not remove `usr/bin` directory from inside snap as this is where `intel_gpu_top` is installed :facepalm: 
* Only install `intel-gpu-tools` for AMD64 as the package is not published for ARM64