### PR TITLE
Preserve include dir and bump command-chain script to latest version

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -40,8 +40,10 @@ jobs:
         uses: actions/checkout@v4
       - name: Build job file from template with oemscript provisioning
         env:
-          QUEUE: "dell-xps-13-9340-c32267"
-          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso"
+          QUEUE: "dell-precision-5690-0cc8-c33253"
+          PROVISION_DATA: "url: https://tel-image-cache.canonical.com/oem-share/somerville/Platforms/jellyfish-magmar/X119_A00/dell-bto-jammy-jellyfish-magmar-X119-20240104-9_A00.iso"
+          #QUEUE: "dell-xps-13-9340-c32267"
+          #PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso"
         run: |
           sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
           -e "s|REPLACE_QUEUE|${QUEUE}|" \

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -40,10 +40,8 @@ jobs:
         uses: actions/checkout@v4
       - name: Build job file from template with oemscript provisioning
         env:
-          QUEUE: "dell-precision-5690-0cc8-c33253"
-          PROVISION_DATA: "url: https://tel-image-cache.canonical.com/oem-share/somerville/Platforms/jellyfish-magmar/X119_A00/dell-bto-jammy-jellyfish-magmar-X119-20240104-9_A00.iso"
-          #QUEUE: "dell-xps-13-9340-c32267"
-          #PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso"
+          QUEUE: "dell-xps-13-9340-c32267"
+          PROVISION_DATA: "url: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso"
         run: |
           sed -e "s|REPLACE_BRANCH|${BRANCH}|" \
           -e "s|REPLACE_QUEUE|${QUEUE}|" \

--- a/sample-consumer/snap/snapcraft.yaml
+++ b/sample-consumer/snap/snapcraft.yaml
@@ -124,7 +124,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2024.6.0-1
+    source-tag: 2024.6.0-4
     stage:
       - command-chain/openvino-launch
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -40,9 +40,6 @@ parts:
       craftctl default
       git submodule update --init --recursive
       craftctl set version="$(git describe --tags)"
-    override-build: |
-      craftctl default
-      rm -rf ${CRAFT_PART_INSTALL}/usr/{share,include}
     build-packages:
       - ca-certificates
       - file


### PR DESCRIPTION
The audacity plugins (and its dependencies) depend on some headers form the OpenVINO toolkit package. I removed these in the past to keep the snap as lean as possible, so this PR adds them back.

While I was at it I went ahead and re-added files from `/usr/share`, and bumped the command-chain script to the latest version inside the sample consumer app to bring the CI up to date. 