### PR TITLE
Bump version to 2025.1.0

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -52,4 +52,4 @@ jobs:
         uses: canonical/testflinger/.github/actions/submit@main
         with:
           poll: true
-          job-path: ${GITHUB_WORKSPACE}/job.yaml
+          job-path: ${{ github.workspace }}/job.yaml

--- a/sample-consumer/snap/snapcraft.yaml
+++ b/sample-consumer/snap/snapcraft.yaml
@@ -98,11 +98,16 @@ parts:
       # Install Intel graphics compiler and compute runtime
       # This is required to enable GPU support for OpenVINO
       # https://docs.openvino.ai/2024/get-started/configurations/configurations-intel-gpu.html
-      wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-core-2_2.5.6+18417_amd64.deb
-      wget https://github.com/intel/intel-graphics-compiler/releases/download/v2.5.6/intel-igc-opencl-2_2.5.6+18417_amd64.deb
-      wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-level-zero-gpu_1.6.32224.5_amd64.deb
-      wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/intel-opencl-icd_24.52.32224.5_amd64.deb
-      wget https://github.com/intel/compute-runtime/releases/download/24.52.32224.5/libigdgmm12_22.5.5_amd64.deb
+      intel_graphics_compiler_version="2.10.8"
+      intel_graphics_compiler_build="18926"
+      compute_runtime_version="25.13.33276.16"
+      intel_level_zero_gpu_version="1.6.33276.16"
+      lib_igdgmm12_version="22.7.0"
+      wget https://github.com/intel/intel-graphics-compiler/releases/download/v${intel_graphics_compiler_version}/intel-igc-core-2_${intel_graphics_compiler_version}+${intel_graphics_compiler_build}_amd64.deb
+      wget https://github.com/intel/intel-graphics-compiler/releases/download/v${intel_graphics_compiler_version}/intel-igc-opencl-2_${intel_graphics_compiler_version}+${intel_graphics_compiler_build}_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/intel-level-zero-gpu_${intel_level_zero_gpu_version}_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/intel-opencl-icd_${compute_runtime_version}_amd64.deb
+      wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/libigdgmm12_${libigdgmm12_version}_amd64.deb
       dpkg --root=$CRAFT_PART_INSTALL --force-all -i *.deb
       # update paths to the Intel Installable Client Drivers (ICDs) for OpenCL
       intel_icd="${CRAFT_PART_INSTALL}"/etc/OpenCL/vendors/intel.icd

--- a/sample-consumer/snap/snapcraft.yaml
+++ b/sample-consumer/snap/snapcraft.yaml
@@ -102,7 +102,7 @@ parts:
       intel_graphics_compiler_build="18926"
       compute_runtime_version="25.13.33276.16"
       intel_level_zero_gpu_version="1.6.33276.16"
-      lib_igdgmm12_version="22.7.0"
+      libigdgmm12_version="22.7.0"
       wget https://github.com/intel/intel-graphics-compiler/releases/download/v${intel_graphics_compiler_version}/intel-igc-core-2_${intel_graphics_compiler_version}+${intel_graphics_compiler_build}_amd64.deb
       wget https://github.com/intel/intel-graphics-compiler/releases/download/v${intel_graphics_compiler_version}/intel-igc-opencl-2_${intel_graphics_compiler_version}+${intel_graphics_compiler_build}_amd64.deb
       wget https://github.com/intel/compute-runtime/releases/download/${compute_runtime_version}/intel-level-zero-gpu_${intel_level_zero_gpu_version}_amd64.deb

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ parts:
   openvino:
     source-type: git
     source: https://github.com/openvinotoolkit/openvino.git
-    source-tag: 2024.6.0
+    source-tag: 2025.1.0
     plugin: cmake
     cmake-parameters:
       - -DENABLE_PYTHON=ON


### PR DESCRIPTION
Note this also bumps the compute runtime and graphics compiler bits used by the sample consumer in the CI to the latest versions while I'm at it.