### PR TITLE
Promote grade to stable based on support agreement

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -4,7 +4,7 @@ summary: Intel's OpenVINO Toolkit
 description: |
   OpenVINO™ is an open-source toolkit for optimizing and deploying AI inference.
 
-grade: devel
+grade: stable
 confinement: strict
 adopt-info: openvino
 


### PR DESCRIPTION
Until now the snap has been published in `edge` and `beta` only, this PR will enable us to now also promote to `candidate` and `stable`.