### PR TITLE
Add openvino_genai and openvino_tokenizers to snap

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -81,7 +81,7 @@ jobs:
           # Dell XPS 13 9340, Meteor Lake, 24.04
           - { queue: dell-xps-13-9340-c34207, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
           # Dell Pro Max 14, Arrow Lake, 24.04
-          #- { queue: dell-pro-max-14-mc14250-0cf0-c36739, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
+          - { queue: dell-pro-max-14-mc14250-0cf0-c36739, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
       fail-fast: false
     steps:
       - name: Check out code

--- a/sample-consumer/snap/snapcraft.yaml
+++ b/sample-consumer/snap/snapcraft.yaml
@@ -38,7 +38,7 @@ plugs:
 apps:
   validate-openvino:
     command-chain: ["command-chain/openvino-launch"]
-    command: usr/bin/python3 $SNAP/validate_openvino.py
+    command: /usr/bin/python3 $SNAP/validate_openvino.py
     plugs:
       - opengl # Intel GPU access (device nodes)
       - intel-npu # Intel NPU access (device node)
@@ -55,45 +55,6 @@ parts:
     plugin: dump
     stage:
       - validate_openvino.py
-
-  python-deps:
-    source: src/
-    plugin: python
-    python-packages: 
-      - pytest
-      - numpy>=1.16.6,<2.3.0 # openvino dep
-      - openvino-telemetry>=2023.2.1 # openvino dep
-      - packaging # openvino dep
-    stage-packages:
-      - python3-minimal # python interpreter
-      - python3.12-minimal # python interpreter
-      - libva2 # openvino gpu plugin dep
-      - libgl1 # opencv-python dep
-      - libglu1-mesa # opencv-python dep
-      - libxcb1 # opencv-python dep
-      - libice6 # opencv-python dep
-      - libsm6 # opencv-python dep
-      - libx11-6 # opencv-python dep
-      - libxext6 # opencv-python dep
-    stage:
-      - -usr/lib/x86_64-linux-gnu/libGLU.so.1.3.1
-      - -usr/lib/x86_64-linux-gnu/libGLX_mesa.so.0.0.0
-      - -usr/lib/x86_64-linux-gnu/libicuio.so.74.2
-      - -usr/lib/x86_64-linux-gnu/libicutest.so.74.2
-      - -usr/lib/x86_64-linux-gnu/libvulkan.so.1.3.275
-      - -usr/lib/x86_64-linux-gnu/libOpenGL.so.0.0.0
-      - -usr/lib/x86_64-linux-gnu/libXfixes.so.3.1.0
-      - -usr/lib/x86_64-linux-gnu/libXxf86vm.so.1.0.0
-      - -usr/lib/x86_64-linux-gnu/libicutu.so.74.2
-      - -usr/lib/x86_64-linux-gnu/libxcb-dri2.so.0.0.0
-      - -usr/lib/x86_64-linux-gnu/libxcb-glx.so.0.0.0
-      - -usr/lib/x86_64-linux-gnu/libxcb-present.so.0.0.0
-      - -usr/lib/x86_64-linux-gnu/libxcb-randr.so.0.1.0
-      - -usr/lib/x86_64-linux-gnu/libxcb-shm.so.0.0.0
-      - -usr/lib/x86_64-linux-gnu/libxcb-sync.so.1.0.0
-      - -usr/lib/x86_64-linux-gnu/libxcb-xfixes.so.0.0.0
-      - -usr/lib/x86_64-linux-gnu/libxshmfence.so.1.0.0
-      - -usr/lib/x86_64-linux-gnu/libicui18n.so.74.2
 
   intel-graphics:
     plugin: nil
@@ -117,7 +78,7 @@ parts:
     plugin: dump
     source-type: git
     source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2025.1.0-0
+    source-tag: 2025.2.0-amd64-rev30
     stage:
       - command-chain/openvino-launch
 

--- a/sample-consumer/src/validate_openvino.py
+++ b/sample-consumer/src/validate_openvino.py
@@ -4,3 +4,8 @@ core = ov.Core()
 devices = core.get_available_devices()
 
 print(f"Supported devices: {devices}")
+
+import openvino_tokenizers
+import openvino_genai
+
+print("Successfully imported openvino_tokenizers and openvino_genai")

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,7 @@ slots:
       - /
 
 parts:
+
   openvino:
     source-type: git
     source: https://github.com/openvinotoolkit/openvino.git
@@ -36,9 +37,12 @@ parts:
       - -DCPACK_GENERATOR=DEB
       - -DENABLE_SAMPLES=OFF
       - -DENABLE_PYTHON_PACKAGING=ON
+      - -DOPENVINO_EXTRA_MODULES=./openvino.genai
+      - -DCPACK_ARCHIVE_COMPONENT_INSTALL=OFF
     override-pull: |
       craftctl default
       git submodule update --init --recursive
+      git clone -b 2025.2.0.0 --recursive https://github.com/openvinotoolkit/openvino.genai.git
       craftctl set version="$(git describe --tags)"
     override-build: |
       # openvino build requires recent version of setuptools
@@ -80,6 +84,39 @@ parts:
       - libsnappy1v5
       - to amd64:
         - intel-gpu-tools
+    organize:
+      usr/runtime/lib/intel64/libopenvino_tokenizers.so: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/libopenvino_tokenizers.so
+      usr/runtime/lib/intel64/libopenvino_genai.*: usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/
+      usr/python/openvino_genai: usr/lib/python3/dist-packages/openvino_genai
+
+  openvino-deps:
+    source: .
+    plugin: python
+    python-packages:
+      - numpy==2.2.6
+      - packaging==25.0
+    organize:
+      lib/python3.12/site-packages/numpy: usr/lib/python3/dist-packages/numpy
+      lib/python3.12/site-packages/numpy.libs: usr/lib/python3/dist-packages/numpy.libs
+      lib/python3.12/site-packages/packaging: usr/lib/python3/dist-packages/packaging
+
+  openvino-tokenizers:
+    # build openvino_tokenizers from source to ensure binary compatability with openvino
+    after: [openvino]
+    source-type: git
+    source: https://github.com/openvinotoolkit/openvino_tokenizers
+    source-tag: 2025.2.0.0
+    plugin: nil
+    build-packages:
+    - libtbb-dev
+    build-environment:
+      - OpenVINO_DIR: $CRAFT_STAGE/usr/lib/$CRAFT_ARCH_TRIPLET_BUILD_FOR/cmake
+    override-build: |
+      # note, extra-index-url is needed for build dependencies only
+      pip install --break-system-packages --no-deps . --extra-index-url https://storage.openvinotoolkit.org/simple/wheels/nightly
+      cp -r $CRAFT_PART_BUILD/python $CRAFT_PART_INSTALL
+    organize:
+      python/openvino_tokenizers: usr/lib/python3/dist-packages/openvino_tokenizers
 
 lint:
   ignore:


### PR DESCRIPTION
The latest version of the OpenVINO GIMP plugins and the upcoming release of the OpenVINO Audacity plugins now both depend on the `openvino_genai` package, which itself has a dependency on the `openvino_tokenizers` package.

These two packages both require strict binary compatibility with the openvino library. Therefore, in order for users to leverage these packages and ensure compatibility with the `openvino-toolkit-2404` snap, in this PR I add both of these packages (and a few more runtime dependencies for openvino) to the snap.

I also simplified the sample consumer snap as it now can get its essential runtime dependencies from the snap. `python-opencv` is not essential dependency, it's just used as an additional package in many of the openvino demos, so I removed it from the sample consumer snap, as well as the many apt dependencies that it brought in.

I've tested this locally against the sample consumer snap and a local version of the latest release of the GIMP plugins.