### PR TITLE
sample-consumer: use python interpreter from base snap

### DIFF
--- a/sample-consumer/snap/snapcraft.yaml
+++ b/sample-consumer/snap/snapcraft.yaml
@@ -38,7 +38,7 @@ plugs:
 apps:
   validate-openvino:
     command-chain: ["command-chain/openvino-launch"]
-    command: /usr/bin/python3 $SNAP/validate_openvino.py
+    command: ./validate_openvino.py
     plugs:
       - opengl # Intel GPU access (device nodes)
       - intel-npu # Intel NPU access (device node)

--- a/sample-consumer/src/validate_openvino.py
+++ b/sample-consumer/src/validate_openvino.py
@@ -1,11 +1,13 @@
-import openvino as ov
+#!/usr/bin/env python3
 
-core = ov.Core()
-devices = core.get_available_devices()
+def main():
+    import openvino as ov
+    core = ov.Core()
+    devices = core.get_available_devices()
+    print(f"Supported devices: {devices}")
+    import openvino_tokenizers
+    import openvino_genai
+    print("Successfully imported openvino_tokenizers and openvino_genai")
 
-print(f"Supported devices: {devices}")
-
-import openvino_tokenizers
-import openvino_genai
-
-print("Successfully imported openvino_tokenizers and openvino_genai")
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
I removed the `python` interpreter from the sample consumer snap in https://github.com/canonical/openvino-toolkit-snap/pull/20 in an _attempt_ to rely on the python interpreter from the base snap (as suggested in snapcraft docs), but it seems you cannot reference the python interpreter directly in a snap's `app` section (I tested the build locally in my previous PR but I must've needed a `snapcraft clean` before testing). This PR makes the python script executable and adds a shebang to the script so it can be run without referencing any explicit path to the python interpreter used inside the snap. I have tested locally and ensured the build environment was clean this time. :)