### PR TITLE
Fix bugs in integration tests

### DIFF
--- a/.github/testflinger/set-device-access.sh
+++ b/.github/testflinger/set-device-access.sh
@@ -3,7 +3,7 @@
 # Set non-root access to NPU device nodes.
 #
 
-if [ "${SNAP_UID}" -ne 0 ]; then
+if [ "${UID}" -ne 0 ]; then
   >&2 echo "
 Please re-run the command with sudo:
 

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
@@ -75,7 +75,7 @@ requires:
 command:
   # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
-  supported_devices=$(openvino-sample-consumer.validate-openvino | tail -n1 | cut -f2 -d":")
+  supported_devices=$(openvino-sample-consumer.validate-openvino | awk -F ':' '/Supported devices/{print $2}')
   if ! echo ${supported_devices} | grep -qw "CPU" ; then
     >&2 echo "Test failure: CPU not detected by OpenVINO Python API."
     exit 1
@@ -93,7 +93,7 @@ requires:
 command:
   # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
-  supported_devices=$(openvino-sample-consumer.validate-openvino | tail -n1 | cut -f2 -d":")
+  supported_devices=$(openvino-sample-consumer.validate-openvino | awk -F ':' '/Supported devices/{print $2}')
   if ! echo ${supported_devices} | grep -qw "GPU" ; then
     >&2 echo "Test failure: GPU not detected by OpenVINO Python API."
     exit 1
@@ -111,7 +111,7 @@ requires:
 command:
   # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
-  supported_devices=$(openvino-sample-consumer.validate-openvino | tail -n1 | cut -f2 -d":")
+  supported_devices=$(openvino-sample-consumer.validate-openvino | awk -F ':' '/Supported devices/{print $2}')
   if ! echo ${supported_devices} | grep -qw "NPU" ; then
     >&2 echo "Test failure: NPU not detected by OpenVINO Python API."
     exit 1


### PR DESCRIPTION
A few fixes:

* The `set-device-access.sh` script no longer runs inside a snap, so switch from using the `SNAP_UID` shell var to `UID` instead.

* The sample consumer validation script outputs an additional line from a recent PR. Update the piped command to select the desired lines in a correct and more future-proof way.

