### PR TITLE
Build command-chain script into snap

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,31 +2,6 @@
 
 This is a content producer snap that provides the OpenVINO runtime libraries for consumption by downstream applications.
 
-## Example `snapcraft.yaml` for consuming applications
+## Sample Python applications
 
-An example snippet for a consuming app's `snapcraft.yaml` might look like the following:
-
-```yaml
-plugs:
-  openvino-libs:
-    interface: content
-    content: openvino-libs-2404
-    target: $SNAP/openvino
-
-apps:
-  openvino-enabled-app:
-    command-chain: ["command-chain/openvino-launch"]
-    command: ...
-    plugs:
-      - openvino-libs
-
-parts:
-  ...
-  command-chain-openvino:
-    plugin: dump
-    source-type: git
-    source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2024.5.0-0
-    stage:
-      - command-chain/openvino-launch
-```
+For reference, a sample consumer application using the OpenVINO Python API is provided in the `sample-consumer` folder. This provides an example of how to build a snap package that leverages the OpenVINO runtime and supports the Intel GPU and NPU for inference.

--- a/command-chain/openvino-launch
+++ b/command-chain/openvino-launch
@@ -66,5 +66,3 @@ done
 for node in /dev/accel/accel*; do
   check_user_access "${node}"
 done
-
-exec "$@"

--- a/sample-consumer/README.md
+++ b/sample-consumer/README.md
@@ -12,7 +12,7 @@ snapcraft
 sudo snap install --dangerous ./openvino-sample-consumer_1.0.0_amd64.snap
 ```
 
-If you have not already, also install the `openvino-toolkit-2404` and `intel-npu-driver` snaps. The first is required while the second is optional for machines containing an Intel NPU.
+If you have not already, also install the `openvino-toolkit-2404` and `intel-npu-driver` snaps. The first is required while the second is optional for machines containing an Intel NPU, which is an AI inference accelerator built into Intel Core Ultra CPUs starting with Meteor Lake.
 
 ```
 sudo snap install openvino-toolkit-2404 # required

--- a/sample-consumer/README.md
+++ b/sample-consumer/README.md
@@ -1,4 +1,4 @@
-# Sample content consumer app for openvino-toolkit-2404
+# Sample content consumer app for `openvino-toolkit-2404`
 
 ## Building
 
@@ -10,6 +10,13 @@ snapcraft
 
 ```
 sudo snap install --dangerous ./openvino-sample-consumer_1.0.0_amd64.snap
+```
+
+If you have not already, also install the `openvino-toolkit-2404` and `intel-npu-driver` snaps. The first is required while the second is optional for machines containing an Intel NPU.
+
+```
+sudo snap install openvino-toolkit-2404 # required
+sudo snap install intel-npu-driver # optional
 ```
 
 ## Connecting snapd interfaces

--- a/sample-consumer/command-chain/source-content-producer
+++ b/sample-consumer/command-chain/source-content-producer
@@ -1,0 +1,13 @@
+#!/bin/bash
+#
+# Source wrapper scripts from content producer snap.
+#
+
+shopt -s nullglob
+
+for wrapper in \
+  "${SNAP}"/openvino/command-chain/openvino-launch* ;
+do
+  source "${wrapper}"
+done
+exec "$@"

--- a/sample-consumer/snap/snapcraft.yaml
+++ b/sample-consumer/snap/snapcraft.yaml
@@ -37,7 +37,7 @@ plugs:
 
 apps:
   validate-openvino:
-    command-chain: ["command-chain/openvino-launch"]
+    command-chain: ["command-chain/source-content-producer"]
     command: ./validate_openvino.py
     plugs:
       - opengl # Intel GPU access (device nodes)
@@ -74,13 +74,11 @@ parts:
       - libigdgmm12
       - libigdgmm-dev
 
-  command-chain-openvino:
+  command-chain:
     plugin: dump
-    source-type: git
-    source: https://github.com/canonical/openvino-toolkit-snap.git
-    source-tag: 2025.2.0-amd64-rev30
-    stage:
-      - command-chain/openvino-launch
+    source: command-chain/
+    organize:
+      source-content-producer: command-chain/source-content-producer
 
 lint:
   ignore:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -118,6 +118,12 @@ parts:
     organize:
       python/openvino_tokenizers: usr/lib/python3/dist-packages/openvino_tokenizers
 
+  command-chain:
+    plugin: dump
+    source: command-chain/
+    organize:
+      openvino-launch: command-chain/openvino-launch
+
 lint:
   ignore:
     - library:


### PR DESCRIPTION
This builds the command-chain script into the snap so it can be sourced from consuming applications. This allows new versions of the script to be more easily deployed (it removes the need to bump the version/tag in the downstream snap).