### PR TITLE
Update test devices for integration testing

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -62,3 +62,7 @@ test_data:
     _run checkbox-openvino-toolkit-2404.install-full-deps
     _run sudo bash set-device-access.sh
     _run checkbox-openvino-toolkit-2404.test-runner-automated
+reserve_data:
+  ssh_keys:
+    - lp:wfrench
+  timeout: 21600

--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -62,7 +62,3 @@ test_data:
     _run checkbox-openvino-toolkit-2404.install-full-deps
     _run sudo bash set-device-access.sh
     _run checkbox-openvino-toolkit-2404.test-runner-automated
-reserve_data:
-  ssh_keys:
-    - lp:wfrench
-  timeout: 21600

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,7 +14,6 @@ on:
       - '.github/testflinger/**'
     branches:
       - openvino-toolkit-2404
-      - fix/integration-tests
   workflow_dispatch:
 
 concurrency:

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -77,14 +77,12 @@ jobs:
     strategy:
       matrix:
         device:
-          # Dell XPS 13 9340, Meteor Lake, 22.04
-          - { queue: dell-xps-13-9340-c32267, image: http://10.102.196.9/somerville/Platforms/jellyfish-treecko/FVR_X113/dell-bto-jammy-jellyfish-treecko-X113-20240131-14.iso }
-          # Dell XPS 13 9340, Meteor Lake, 24.04
+          # Dell XPS 13 9340 Laptop, Meteor Lake, 24.04
           - { queue: dell-xps-13-9340-c34207, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
-          # Dell Pro Max 14, Arrow Lake, 24.04
-          - { queue: dell-pro-max-14-mc14250-0cf0-c36739, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
-          # Dell XPS 13 9350, Lunar Lake, 24.04
-          - { queue: dell-xps-13-9350-0cc9-c34216, image: https://tel-image-cache.canonical.com/oem-share//somerville/releases/noble/oem-24.04b-proposed/20241224-151/somerville-noble-oem-24.04b-proposed-20241224-151.iso }
+          # Dell Pro Max Tower T2 Desktop, Arrow Lake, 24.04
+          - { queue: dell-pro-max-tower-f0t2250-0ce1-c36197, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04b-proposed/20241220-148/somerville-noble-oem-24.04b-proposed-20241220-148.iso }
+          # Dell XPS 13 9350 Laptop, Lunar Lake, 24.04
+          - { queue: dell-xps-13-9350-c36962, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04c/20250801-32/somerville-noble-oem-24.04c-20250801-32.iso }
       fail-fast: false
     steps:
       - name: Check out code

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -14,6 +14,7 @@ on:
       - '.github/testflinger/**'
     branches:
       - openvino-toolkit-2404
+      - fix/integration-tests
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
* Remove old dell device that depends on a 22.04 image. The 6.5 kernel in the image does not support the NPU inference pipeline that was recently added to the CI. Upgrading to a 6.8 kernel fixes the issue, but to simplify maintenance it's best to simply remove the device from the CI.
* Switch to different Arrow Lake desktop device. The previous one was unable to reach the WAN and is also not actively tested by the cert team in jenkins.
* Switch to different Lunar Lake laptop device. The new device uses a newer image based on 24.04.2 and 6.14 kernel. The previous device used an older kernel that did not support Lunar Lakes graphics.