### PR TITLE
Bump upstream version, upload to test observer, configure renovate to watch upstream

### DIFF
--- a/.github/testflinger/job-def.yaml
+++ b/.github/testflinger/job-def.yaml
@@ -12,7 +12,7 @@ test_data:
       agent: "set-device-access.sh"
   test_cmds: |
 
-    set -e
+    set -x
 
     # retrieve the tools installer
     curl -Ls -o install_tools.sh https://raw.githubusercontent.com/canonical/hwcert-jenkins-tools/main/install_tools.sh
@@ -31,20 +31,6 @@ test_data:
     echo "==========================================="
     echo
 
-    echo
-    echo "========== TARGET DEVICE OS INFO =========="
-    echo
-    echo "*** OS Release ***"
-    echo
-    _run lsb_release -a
-    echo
-    echo "*** Kernel ***"
-    echo
-    _run uname -a
-    echo
-    echo "==========================================="
-    echo
-
     # Avoid GPG errors on old unsupported versions of Chrome, which we don't test anyway
     _run sudo rm -f /etc/apt/sources.list.d/google-chrome.list
 
@@ -59,6 +45,22 @@ test_data:
 
     _put attachments/test/set-device-access.sh :/home/ubuntu/set-device-access.sh
 
+    # Run the validation twice:
+    #
+    # Run 1: original debs and kernel from the certified image
+    # Run 2: upgraded debs and kernel, following a reboot
+    #
     _run checkbox-openvino-toolkit-2404.install-full-deps
     _run sudo bash set-device-access.sh
     _run checkbox-openvino-toolkit-2404.test-runner-automated
+    mkdir -p artifacts
+    _get '/home/ubuntu/.local/share/checkbox-ng/*.tar.xz' artifacts/
+
+    _run sudo apt update
+    _run sudo apt -y upgrade
+    _run sudo reboot
+    wait_for_ssh --allow-degraded
+
+    _run sudo bash set-device-access.sh
+    _run checkbox-openvino-toolkit-2404.test-runner-automated
+    _get '/home/ubuntu/.local/share/checkbox-ng/*.tar.xz' artifacts/

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,49 @@
+name: Build
+
+on:
+  pull_request:
+    paths:
+      - 'snap/**'
+      - 'command-chain/**'
+      - '.github/workflows/build.yaml'
+    branches: ["**"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build snap and run smoke tests
+    runs-on: [self-hosted, linux, X64, xlarge, jammy]
+    # Only run on PRs from branches in the same repository (not forks)
+    # This ensures only trusted sources can trigger this workflow
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    steps:
+      - name: Checkout the source
+        uses: actions/checkout@v6
+      - name: Find and parse snapcraft.yaml
+        id: snapcraft-yaml
+        uses: snapcrafters/ci/parse-snapcraft-yaml@main
+      - name: Build snap
+        uses: snapcore/action-build@v1
+        id: build
+        with:
+          path: ${{ steps.snapcraft-yaml.outputs.project-root }}
+      - name: Upload snap artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: openvino-toolkit-2404-${{ github.event.pull_request.head.sha || github.sha }}
+          path: ${{ steps.build.outputs.snap }}
+          retention-days: 30
+      - name: Review the built snap
+        uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          isClassic: ${{ steps.snapcraft-yaml.outputs.classic }}
+          plugs: ${{ steps.snapcraft-yaml.outputs.plugs-file }}
+          slots: ${{ steps.snapcraft-yaml.outputs.slots-file }}
+      - name: Install the snap
+        shell: bash
+        run: |
+          sudo snap install --dangerous "${{ steps.build.outputs.snap }}"

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -1,17 +1,10 @@
 name: Integration tests
 
 on:
-  push:
-    paths:
-      - 'snap/**'
-      - 'command-chain/**'
-      - 'checkbox/bin/**'
-      - 'checkbox/checkbox-provider-openvino-toolkit-2404/**'
-      - 'checkbox/snap/**'
-      - 'sample-consumer/src/**'
-      - 'sample-consumer/snap/**'
-      - '.github/workflows/integration-tests.yaml'
-      - '.github/testflinger/**'
+  workflow_run:
+    workflows: ["Release"]
+    types:
+      - completed
     branches:
       - openvino-toolkit-2404
   workflow_dispatch:
@@ -23,6 +16,7 @@ concurrency:
 env:
   CHECKBOX_PROVIDER_NAME: checkbox-openvino-toolkit-2404
   SAMPLE_CONSUMER_NAME: sample-consumer
+  TEST_OBSERVER_URL: https://test-observer-api-staging.canonical.com
 
 jobs:
   build-checkbox-provider:
@@ -30,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Find and parse snapcraft.yaml
         id: snapcraft-yaml
         uses: snapcrafters/ci/parse-snapcraft-yaml@main
@@ -43,16 +37,17 @@ jobs:
           path: ${{ steps.snapcraft-yaml.outputs.project-root }}
           snapcraft-args: "-o ${{ env.CHECKBOX_PROVIDER_NAME }}.snap"
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.CHECKBOX_PROVIDER_NAME }}
           path: ${{ steps.build.outputs.snap }}
+
   build-sample-consumer:
     name: Sample consumer build
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Find and parse snapcraft.yaml
         id: snapcraft-yaml
         uses: snapcrafters/ci/parse-snapcraft-yaml@main
@@ -65,31 +60,34 @@ jobs:
           path: ${{ steps.snapcraft-yaml.outputs.project-root }}
           snapcraft-args: "-o ${{ env.SAMPLE_CONSUMER_NAME }}.snap"
       - name: Upload snap artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.SAMPLE_CONSUMER_NAME }}
           path: ${{ steps.build.outputs.snap }}
+
   testflinger-validation:
     name: Testflinger Validation
     needs: [build-checkbox-provider, build-sample-consumer]
-    runs-on: [self-hosted, self-hosted-linux-amd64-jammy-private-endpoint-medium]
+    runs-on: self-hosted-linux-amd64-noble-private-endpoint-small
+    # Only run if the release workflow completed successfully
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
     strategy:
       matrix:
         device:
           # Dell XPS 13 9340 Laptop, Meteor Lake, 24.04
-          - { queue: dell-xps-13-9340-c34207, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
+          - { queue: dell-xps-13-9340-c34051, gen: "MTL", image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04a/20240729-53/somerville-noble-oem-24.04a-20240729-53.iso }
           # Dell Pro Max Tower T2 Desktop, Arrow Lake, 24.04
-          - { queue: dell-pro-max-tower-f0t2250-0ce1-c36197, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04b-proposed/20241220-148/somerville-noble-oem-24.04b-proposed-20241220-148.iso }
+          - { queue: dell-pro-max-tower-f0t2250-0ce1-c36197, gen: "ARL", image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04b-proposed/20241220-148/somerville-noble-oem-24.04b-proposed-20241220-148.iso }
           # Dell XPS 13 9350 Laptop, Lunar Lake, 24.04
-          - { queue: dell-xps-13-9350-c36962, image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04c/20250801-32/somerville-noble-oem-24.04c-20250801-32.iso }
+          - { queue: dell-xps-13-9350-c36962, gen: "LNL", image: https://tel-image-cache.canonical.com/oem-share/somerville/releases/noble/oem-24.04c/20250801-32/somerville-noble-oem-24.04c-20250801-32.iso }
       fail-fast: false
     steps:
       - name: Check out code
-        uses: actions/checkout@v4
-      - uses: actions/download-artifact@v4
+        uses: actions/checkout@v6
+      - uses: actions/download-artifact@v7
         with:
           name: ${{ env.CHECKBOX_PROVIDER_NAME }}
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v7
         with:
           name: ${{ env.SAMPLE_CONSUMER_NAME }}
       - name: Build job file from template with oemscript provisioning
@@ -101,17 +99,140 @@ jobs:
           ${GITHUB_WORKSPACE}/.github/testflinger/job-def.yaml > \
           ${GITHUB_WORKSPACE}/job.yaml
       - name: Submit testflinger job
+        id: submit
+        continue-on-error: true
         uses: canonical/testflinger/.github/actions/submit@main
         with:
           poll: true
           job-path: ${{ github.workspace }}/job.yaml
+      - name: Download checkbox artifacts
+        id: artifacts
+        run: |
+          # Download the job artifacts with retry logic
+          for attempt in {1..10}; do
+            echo "Attempt $attempt: Downloading artifacts..."
+            if testflinger artifacts ${{ steps.submit.outputs.id }}; then
+              echo "Successfully downloaded artifacts"
+              break
+            else
+              if [ $attempt -eq 10 ]; then
+                echo "Failed to download artifacts after 10 attempts"
+                exit 1
+              fi
+              echo "Failed to download artifacts, retrying in 60 seconds..."
+              sleep 60
+            fi
+          done
+          tar -xzf artifacts.tgz
+
+          # Check if any .tar.xz files exist
+          if ! ls artifacts/*.tar.xz 1> /dev/null 2>&1; then
+            echo "Error: No .tar.xz files found in artifacts/"
+            ls -la artifacts/
+            exit 1
+          fi
+
+          # Extract submission.json from each tarball.
+          #
+          # This is necessary because the test plan is run twice:
+          # - Once on the original OEM image
+          # - Once after upgrading all apt packages and rebooting
+          #
+          # The test observer uploader action cannot account for multiple
+          # submissions in a single run, so we need to extract them here and
+          # upload them separately.
+          #
+          queue="${{ matrix.device.queue }}"
+          mkdir -p "extracted-artifacts/$queue"
+          i=0
+          for file in artifacts/*.tar.xz; do
+            if [ -f "$file" ]; then
+              echo "Extracting submission.json from: $file"
+              run_dir="extracted-artifacts/$queue/run-$i"
+              mkdir -p "$run_dir"
+
+              # Extract only submission.json
+              tar -xJf "$file" submission.json -O > "$run_dir/submission.json"
+
+              # Build environment key, for example: env0=MTL-24.04.3-6.17-generic
+              kernel_ver=$(jq -r '[.system_information | .. | objects | to_entries[] | select(.key | endswith("#Kernel")) | .value] | first' "$run_dir/submission.json")
+              os_ver=$(jq -r '[.system_information | .. | objects | to_entries[] | select(.key | endswith("#Distro")) | .value] | first | match("Ubuntu ([0-9.]+)") | .captures[0].string' "$run_dir/submission.json")
+              echo "env$i=${{ matrix.device.gen }}-${os_ver}-${kernel_ver}" >> $GITHUB_OUTPUT
+
+              # Save tarball path to output
+              echo "tarball$i=$file" >> $GITHUB_OUTPUT
+
+              i=$((i + 1))
+            fi
+          done
+      - name: Upload checkbox artifacts
+        uses: actions/upload-artifact@v7
+        with:
+          name: checkbox-results-${{ matrix.device.queue }}
+          path: extracted-artifacts/
+      - name: Get numeric job ID
+        id: job-id
+        run: |
+          jobs=$(gh api /repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/jobs)
+          # Matrix jobs include the matrix values in their name, e.g. "Testflinger Validation (dell-xps-13-9350-c36962, https://...)"
+          # We need to match based on the queue name which is unique per matrix instance
+          job_id=$(echo "$jobs" | jq -r '.jobs[] | select(.name | contains("${{ matrix.device.queue }}")) | .id')
+          echo "id=$job_id" >> $GITHUB_OUTPUT
+        env:
+          GH_TOKEN: ${{ github.token }}
+      - name: Generate TO start-payload
+        run: |
+          test_plan=$(grep "^unit = " ${GITHUB_WORKSPACE}/.github/testflinger/checkbox-launcher | cut -d '=' -f2 | xargs)
+          revision=$(snap info openvino-toolkit-2404 | grep latest/edge | cut -d "(" -f2 | cut -d ")" -f1)
+          version=$(snap info openvino-toolkit-2404 | grep latest/edge | awk '{print $2}')
+          cat <<EOF > start-payload-0.json
+          {
+            "name": "openvino-toolkit-2404",
+            "version": "${version}",
+            "arch": "amd64",
+            "test_plan": "${test_plan}",
+            "environment": "${{ steps.artifacts.outputs.env0 }}",
+            "initial_status": "IN_PROGRESS",
+            "needs_assignment": false,
+            "family": "snap",
+            "revision": "${revision}",
+            "track": "latest",
+            "store": "ubuntu",
+            "branch": "",
+            "execution_stage": "edge"
+          }
+          EOF
+          jq '.environment = "${{ steps.artifacts.outputs.env1 }}"' start-payload-0.json > start-payload-1.json
+      - name: Upload first test results to test observer
+        if: steps.artifacts.outputs.tarball0 != ''
+        uses: canonical/partner-eng-gh-actions/.github/actions/test-observer-uploader@v8.2
+        with:
+          results_type: checkbox
+          owner: kobuk
+          start_test_api_payload: start-payload-0.json
+          ci_link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ steps.job-id.outputs.id }}#pre-upgrade
+          results: ${{ steps.artifacts.outputs.tarball0 }}
+          test_observer_url: ${{ env.TEST_OBSERVER_URL }}
+      - name: Upload second test results to test observer
+        if: steps.artifacts.outputs.tarball1 != ''
+        uses: canonical/partner-eng-gh-actions/.github/actions/test-observer-uploader@v8.2
+        with:
+          results_type: checkbox
+          owner: kobuk
+          start_test_api_payload: start-payload-1.json
+          ci_link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ steps.job-id.outputs.id }}#post-upgrade
+          results: ${{ steps.artifacts.outputs.tarball1 }}
+          test_observer_url: ${{ env.TEST_OBSERVER_URL }}
+
   tag:
     name: Push tag for revision
     needs: testflinger-validation
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Create and push tag for revision
         shell: bash
         env:
@@ -122,5 +243,10 @@ jobs:
           revision=$(snap info openvino-toolkit-2404 | grep latest/edge | cut -d "(" -f2 | cut -d ")" -f1)
           version=$(snap info openvino-toolkit-2404 | grep latest/edge | awk '{print $2}')
           tag_name="${version}-amd64-rev${revision}"
-          git tag -a "${tag_name}" -m "Revision ${revision} (amd64)"
-          git push origin "${tag_name}"
+          if git ls-remote --tags origin | grep -q "refs/tags/${tag_name}"; then
+            echo "Tag ${tag_name} already exists in remote repo. Doing nothing."
+          else
+            git tag -a "${tag_name}" -m "Revision ${revision} (amd64)"
+            git push origin "${tag_name}"
+          fi
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,11 @@
-name: Pull Request
+name: Release
 
 on:
-  pull_request:
+  push:
     paths:
       - 'snap/**'
       - 'command-chain/**'
-      - '.github/workflows/pull-request.yaml'
+      - '.github/workflows/release.yaml'
     branches:
       - openvino-toolkit-2404
   workflow_dispatch:
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout the source
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Find and parse snapcraft.yaml
         id: snapcraft-yaml
         uses: snapcrafters/ci/parse-snapcraft-yaml@main
@@ -42,10 +42,6 @@ jobs:
           isClassic: ${{ steps.snapcraft-yaml.outputs.classic }}
           plugs: ${{ steps.snapcraft-yaml.outputs.plugs-file }}
           slots: ${{ steps.snapcraft-yaml.outputs.slots-file }}
-      - name: Install the snap
-        shell: bash
-        run: |
-          sudo snap install --dangerous "${{ steps.build.outputs.snap }}"
       - name: Release to latest/edge
         id: publish
         shell: bash

--- a/checkbox/bin/install-full-deps
+++ b/checkbox/bin/install-full-deps
@@ -21,4 +21,4 @@ then
 fi
 
 sudo DEBIAN_FRONTEND=noninteractive apt install -y intel-gpu-tools
-sudo snap install intel-npu-driver
+sudo snap install intel-npu-driver --edge

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended"
+  ],
+  "regexManagers": [
+    {
+      "fileMatch": ["^snap/snapcraft\\.yaml$"],
+      "matchStrings": [
+        "source:\\s+https://github\\.com/(?<depName>[^/\\s]+/[^/\\s]+)(\\.git)?\\s+source-tag:\\s+(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?)"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    },
+    {
+      "fileMatch": ["^snap/snapcraft\\.yaml$"],
+      "matchStrings": [
+        "git clone -b (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+) --recursive https://github\\.com/(?<depName>[^/]+/[^/]+)\\.git"
+      ],
+      "datasourceTemplate": "github-releases",
+      "versioningTemplate": "semver"
+    }
+  ]
+}

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
 
 grade: stable
 confinement: strict
-version: 2026.2.0
+adopt-info: openvino
 
 website: https://openvino.ai
 contact: https://github.com/canonical/openvino-toolkit-snap/issues
@@ -36,7 +36,7 @@ parts:
   openvino:
     source-type: git
     source: https://github.com/openvinotoolkit/openvino.git
-    source-tag: $CRAFT_PROJECT_VERSION
+    source-tag: 2026.2.0
     plugin: cmake
     cmake-parameters:
       - -DENABLE_PYTHON=ON
@@ -52,8 +52,9 @@ parts:
       - -DCPACK_ARCHIVE_COMPONENT_INSTALL=OFF
     override-pull: |
       craftctl default
+      craftctl set version="$(git describe --tags | tr -d 'v')"
       git submodule update --init --recursive
-      git clone -b $CRAFT_PROJECT_VERSION.0 --recursive https://github.com/openvinotoolkit/openvino.genai.git
+      git clone -b 2026.2.0.0 --recursive https://github.com/openvinotoolkit/openvino.genai.git
       # apply pybind11 fix to openvino.genai
       # https://github.com/openvinotoolkit/openvino.genai/pull/3915
       cd openvino.genai
@@ -122,7 +123,7 @@ parts:
     after: [openvino]
     source-type: git
     source: https://github.com/openvinotoolkit/openvino_tokenizers
-    source-tag: $CRAFT_PROJECT_VERSION.0
+    source-tag: 2026.2.0.0
     plugin: nil
     build-packages:
     - libtbb-dev

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,7 +11,7 @@ description: |
 
 grade: stable
 confinement: strict
-version: 2025.4.0
+version: 2026.2.0
 
 website: https://openvino.ai
 contact: https://github.com/canonical/openvino-toolkit-snap/issues
@@ -54,6 +54,13 @@ parts:
       craftctl default
       git submodule update --init --recursive
       git clone -b $CRAFT_PROJECT_VERSION.0 --recursive https://github.com/openvinotoolkit/openvino.genai.git
+      # apply pybind11 fix to openvino.genai
+      # https://github.com/openvinotoolkit/openvino.genai/pull/3915
+      cd openvino.genai
+      git remote add frenchwr https://github.com/frenchwr/openvino.genai.git
+      git fetch frenchwr frenchwr/pybind11-fix
+      git cherry-pick b67a24ed9a2ca0960925b4b3507d0b2eabaa0357
+      cd ..
     override-build: |
       # openvino build requires recent version of setuptools
       pip install --upgrade setuptools --break-system-packages


### PR DESCRIPTION
- Bump upstream version to latest, 2026.2.0
- Refactor CI to align with intel-npu-driver
- Upload test results to Test Observer