### PR TITLE
Add two models to validation

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -16,7 +16,7 @@ concurrency:
 env:
   CHECKBOX_PROVIDER_NAME: checkbox-openvino-toolkit-2404
   SAMPLE_CONSUMER_NAME: sample-consumer
-  TEST_OBSERVER_URL: https://test-observer-api-staging.canonical.com
+  TEST_OBSERVER_URL: https://test-observer-api.canonical.com
 
 jobs:
   build-checkbox-provider:

--- a/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
+++ b/checkbox/checkbox-provider-openvino-toolkit-2404/units/jobs.pxu
@@ -65,10 +65,10 @@ command:
       exit 1
   fi
 
-id: python/download_model
+id: python/TinyLlama-1.1B-Chat-v1.0-prepare
 category_id: openvino
 flags: simple
-_summary: Download a model and convert to OV IR format using optimum-cli
+_summary: Download TinyLlama-1.1B-Chat-v1.0 and convert to OV IR format using optimum-cli
 estimated_duration: 5s
 requires:
   executable.name == 'openvino-sample-consumer.get-model'
@@ -76,12 +76,12 @@ command:
   # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
   openvino-sample-consumer.get-model TinyLlama/TinyLlama-1.1B-Chat-v1.0
-  echo "Test success: model downloaded and converted to OpenVINO IR format."
+  echo "Test success: TinyLlama-1.1B-Chat-v1.0 model downloaded and converted to OpenVINO IR format."
 
-id: python/devices_avail_cpu
+id: python/TinyLlama-1.1B-Chat-v1.0-cpu-inference
 category_id: openvino
 flags: simple
-_summary: Check that we can use a CPU with the OpenVINO Python API
+_summary: Perform CPU inference using OpenVINO and TinyLlama-1.1B-Chat-v1.0
 estimated_duration: 5s
 requires:
   executable.name == 'openvino-sample-consumer.validate-openvino'
@@ -90,10 +90,10 @@ command:
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
   openvino-sample-consumer.validate-openvino TinyLlama/TinyLlama-1.1B-Chat-v1.0 CPU
 
-id: python/devices_avail_gpu
+id: python/TinyLlama-1.1B-Chat-v1.0-gpu-inference
 category_id: openvino
 flags: simple
-_summary: Check that we can use a GPU with the OpenVINO Python API
+_summary: Perform GPU inference using OpenVINO and TinyLlama-1.1B-Chat-v1.0
 estimated_duration: 5s
 requires:
   executable.name == 'openvino-sample-consumer.validate-openvino'
@@ -103,10 +103,10 @@ command:
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
   openvino-sample-consumer.validate-openvino TinyLlama/TinyLlama-1.1B-Chat-v1.0 GPU
 
-id: python/devices_avail_npu
+id: python/TinyLlama-1.1B-Chat-v1.0-npu-inference
 category_id: openvino
 flags: simple
-_summary: Check that we can use a NPU with the OpenVINO Python API
+_summary: Perform NPU inference using OpenVINO and TinyLlama-1.1B-Chat-v1.0
 estimated_duration: 5s
 requires:
   executable.name == 'openvino-sample-consumer.validate-openvino'
@@ -115,3 +115,105 @@ command:
   # reset environment vars to prevent python environment conflicts
   export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
   openvino-sample-consumer.validate-openvino TinyLlama/TinyLlama-1.1B-Chat-v1.0 NPU
+
+id: python/Qwen-2.5-3B-prepare
+category_id: openvino
+flags: simple
+_summary: Download Qwen-2.5-3B and convert to OV IR format using optimum-cli
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.get-model'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.get-model Qwen/Qwen2.5-3B
+  echo "Test success: Qwen-2.5-3B model downloaded and converted to OpenVINO IR format."
+
+id: python/Qwen-2.5-3B-cpu-inference
+category_id: openvino
+flags: simple
+_summary: Perform CPU inference using OpenVINO and Qwen-2.5-3B
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.validate-openvino Qwen/Qwen2.5-3B CPU
+
+id: python/Qwen-2.5-3B-gpu-inference
+category_id: openvino
+flags: simple
+_summary: Perform GPU inference using OpenVINO and Qwen-2.5-3B
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+  host_gpu.state == 'present'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.validate-openvino Qwen/Qwen2.5-3B GPU
+
+id: python/Qwen-2.5-3B-npu-inference
+category_id: openvino
+flags: simple
+_summary: Perform NPU inference using OpenVINO and Qwen-2.5-3B
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+  host_npu.state == 'present'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.validate-openvino Qwen/Qwen2.5-3B NPU
+
+id: python/Mistral-7B-v0.1-prepare
+category_id: openvino
+flags: simple
+_summary: Download Mistral-7B-v0.1 model and convert to OV IR format using optimum-cli
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.get-model'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.get-model mistralai/Mistral-7B-v0.1
+  echo "Test success: Mistral-7B-v0.1 model downloaded and converted to OpenVINO IR format."
+
+id: python/Mistral-7B-v0.1-cpu-inference
+category_id: openvino
+flags: simple
+_summary: Perform CPU inference using OpenVINO and Mistral-7B-v0.1
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.validate-openvino mistralai/Mistral-7B-v0.1 CPU
+
+id: python/Mistral-7B-v0.1-gpu-inference
+category_id: openvino
+flags: simple
+_summary: Perform GPU inference using OpenVINO and Mistral-7B-v0.1
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+  host_gpu.state == 'present'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.validate-openvino mistralai/Mistral-7B-v0.1 GPU
+
+id: python/Mistral-7B-v0.1-npu-inference
+category_id: openvino
+flags: simple
+_summary: Perform NPU inference using OpenVINO and Mistral-7B-v0.1
+estimated_duration: 5s
+requires:
+  executable.name == 'openvino-sample-consumer.validate-openvino'
+  host_npu.state == 'present'
+command:
+  # reset environment vars to prevent python environment conflicts
+  export -n PYTHONHOME PYTHONPATH PYTHONUSERBASE
+  openvino-sample-consumer.validate-openvino mistralai/Mistral-7B-v0.1 NPU


### PR DESCRIPTION
Add two models to validation, so now we have validation of CPU, GPU, and NPU inference on the following models:

* `TinyLlama/TinyLlama-1.1B-Chat-v1`
* `Qwen/Qwen2.5-3B`
* `mistralai/Mistral-7B-v0.1`

I also tried several other models but encountered various issues, it seems `optimum-cli` does not support all models equally well, especially newer models. For future reference, a comprehensive list of models supported by `openvino.genai` can be found here: https://openvinotoolkit.github.io/openvino.genai/docs/supported-models/#large-language-models-llms

Some of the models I encountered issues with:

* **`microsoft/Phi-3.5-mini-instruct`** and others from same family failed with errors like: `RuntimeError: Couldn't get TorchScript module by tracing.
Exception:
'DynamicCache' object has no attribute 'get_usable_length'`
* **`google/gemma-3-1b-pt`** and others from family require a Huggingface token (these are generally simple to obtain but I prefer to not introduce a token into the pipeline if not necessary)
* **`google/gemma-4-E2B-it`**  this is a multimodal model (supports text and image) which I eventually got working on the GPU only (NPU resulted in seg faults and CPU returned broken responses). I needed to update to an unreleased version of `optimum-cli` with a newer version of `transformers` to get this working as the model was only released a few months ago
* **`mistralai/Mistral-7B-v0.13`** does not fetch a tokenizer config file that is required for the `openvino.genai` pipeline