### PR TITLE
fix: update renovate regex match

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -9,7 +9,7 @@
     {
       "fileMatch": ["^snap/snapcraft\\.yaml$"],
       "matchStrings": [
-        "source:\\s+https://github\\.com/(?<depName>[^/\\s]+/[^/\\s]+)(\\.git)?\\s+source-tag:\\s+(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?)"
+        "source:\\s+https://github\\.com/(?<depName>[^/\\s]+/[^/.\\s]+)(?:\\.git)?\\s+source-tag:\\s+(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?)"
       ],
       "datasourceTemplate": "github-releases",
       "versioningTemplate": "semver"


### PR DESCRIPTION
Fixes:

```
Dependency Lookup Warnings

Renovate failed to look up the following dependencies:

Failed to look up github-releases package openvinotoolkit/openvino.git: no-result

Files affected:

snap/snapcraft.yaml
```