### PR TITLE
fix: group upstream OV package updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,6 +5,17 @@
   ],
   "forkProcessing": "enabled",
   "baseBranches": ["openvino-toolkit-2404"],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "openvinotoolkit/openvino",
+        "openvinotoolkit/openvino.genai",
+        "openvinotoolkit/openvino_tokenizers"
+      ],
+      "groupName": "OpenVINO ecosystem",
+      "minimumReleaseAge": "7 days"
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["^snap/snapcraft\\.yaml$"],


### PR DESCRIPTION
This ensures that `openvino`, `openvino.genai`, and `openvino-tokenizers` are all updated by renovate at matching releases.

Generally `openvino` is released first and the corresponding versions for `openvino.genai` and `openvino-tokenizers` are released shortly after. This PR waits 7 days after it detects a new version of `openvino` released upstream to allow the other two packages to receive their updates.