### PR TITLE
fix: push subcommand deprecated in favor of upload

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -49,4 +49,4 @@ jobs:
           SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_PE_BOT }}
           SNAP_FILE: ${{ steps.build.outputs.snap }}
         run: |
-          snapcraft push "$SNAP_FILE" --release=latest/edge
+          snapcraft upload "$SNAP_FILE" --release=latest/edge


### PR DESCRIPTION
Fixes:

```
$ snapcraft push "$SNAP_FILE" --release=latest/edge
The 'push' command was renamed to 'upload'.
```