### PR TITLE
fix(renovate): use loose versioning for 4-part OpenVINO deps

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -16,22 +16,24 @@
       "minimumReleaseAge": "7 days"
     }
   ],
-  "regexManagers": [
+  "customManagers": [
     {
+      "customType": "regex",
       "fileMatch": ["^snap/snapcraft\\.yaml$"],
       "matchStrings": [
         "source:\\s+https://github\\.com/(?<depName>[^/\\s]+/[^/.\\s]+)(?:\\.git)?\\s+source-tag:\\s+(?<currentValue>v?[0-9]+\\.[0-9]+\\.[0-9]+(\\.[0-9]+)?)"
       ],
       "datasourceTemplate": "github-releases",
-      "versioningTemplate": "semver"
+      "versioningTemplate": "loose"
     },
     {
+      "customType": "regex",
       "fileMatch": ["^snap/snapcraft\\.yaml$"],
       "matchStrings": [
         "git clone -b (?<currentValue>[0-9]+\\.[0-9]+\\.[0-9]+\\.[0-9]+) --recursive https://github\\.com/(?<depName>[^/]+/[^/]+)\\.git"
       ],
       "datasourceTemplate": "github-releases",
-      "versioningTemplate": "semver"
+      "versioningTemplate": "loose"
     }
   ]
 }


### PR DESCRIPTION
semver versioning rejected the 4-part versions used by openvino.genai and openvino_tokenizers (e.g. 2026.2.0.0), causing Renovate to skip them and only update the openvino source-tag. Switch to loose versioning and migrate regexManagers to customManagers.