### PR TITLE
feat: pass API key to test-observer-uploader

### DIFF
--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -184,7 +184,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: canonical/partner-eng-gh-actions
-          ref: frenchwr/test-observer-uploader-auth # TODO: update once merged
+          ref: main
           token: ${{ secrets.PE_BOT_PAT }}
           path: .github/actions/partner-eng-gh-actions
       - name: Generate TO start-payload

--- a/.github/workflows/integration-tests.yaml
+++ b/.github/workflows/integration-tests.yaml
@@ -184,7 +184,7 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: canonical/partner-eng-gh-actions
-          ref: main
+          ref: frenchwr/test-observer-uploader-auth # TODO: update once merged
           token: ${{ secrets.PE_BOT_PAT }}
           path: .github/actions/partner-eng-gh-actions
       - name: Generate TO start-payload
@@ -220,6 +220,7 @@ jobs:
           ci_link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ steps.job-id.outputs.id }}#pre-upgrade
           results: ${{ steps.artifacts.outputs.tarball0 }}
           test_observer_url: ${{ env.TEST_OBSERVER_URL }}
+          api_key: ${{ secrets.TEST_OBSERVER_API_KEY_PRODUCTION }}
       - name: Upload second test results to test observer
         if: steps.artifacts.outputs.tarball1 != ''
         uses: ./.github/actions/partner-eng-gh-actions/.github/actions/test-observer-uploader
@@ -230,6 +231,7 @@ jobs:
           ci_link: https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}/job/${{ steps.job-id.outputs.id }}#post-upgrade
           results: ${{ steps.artifacts.outputs.tarball1 }}
           test_observer_url: ${{ env.TEST_OBSERVER_URL }}
+          api_key: ${{ secrets.TEST_OBSERVER_API_KEY_PRODUCTION }}
 
   tag:
     name: Push tag for revision


### PR DESCRIPTION
Test observer is now public and therefore requires authentication for each API call. This PR updates the integration tests to pass the API key to the `test-observer-uploader` action. 